### PR TITLE
Support --docker-registry option

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -91,6 +91,7 @@ func getCreateClusterCommand() *cobra.Command {
 		Short: "Setup a test cluster on Kubernetes",
 		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
+			dockerRegistry, _ := cmd.Flags().GetString("docker-registry")
 			configNodes, _ := cmd.Flags().GetInt("config-nodes")
 			topoNodes, _ := cmd.Flags().GetInt("topo-nodes")
 			partitions, _ := cmd.Flags().GetInt("partitions")
@@ -113,6 +114,7 @@ func getCreateClusterCommand() *cobra.Command {
 
 			// Create the cluster configuration
 			config := &runner.ClusterConfig{
+				Registry:      dockerRegistry,
 				Preset:        configName,
 				ConfigNodes:   configNodes,
 				TopoNodes:     topoNodes,
@@ -141,8 +143,9 @@ func getCreateClusterCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringP("config", "c", "default", "test cluster configuration")
-	cmd.Flags().IntP("config-nodes", "", 1, "the number of onos-config nodes to deploy")
-	cmd.Flags().IntP("topo-nodes", "", 1, "the number of onos-topo nodes to deploy")
+	cmd.Flags().String("docker-registry", "", "an optional host:port for a private Docker registry")
+	cmd.Flags().Int("config-nodes", 1, "the number of onos-config nodes to deploy")
+	cmd.Flags().Int("topo-nodes", 1, "the number of onos-topo nodes to deploy")
 	cmd.Flags().IntP("partitions", "p", 1, "the number of Raft partitions to deploy")
 	cmd.Flags().IntP("partition-size", "s", 1, "the size of each Raft partition")
 	return cmd

--- a/pkg/runner/cluster.go
+++ b/pkg/runner/cluster.go
@@ -46,6 +46,19 @@ type ClusterController struct {
 	status           *console.StatusWriter
 }
 
+// imageName returns a fully qualified name for the given image
+func (c *ClusterController) imageName(image string) string {
+	return fmt.Sprintf("%s%s", c.imagePrefix(), image)
+}
+
+// imagePrefix returns a prefix for images
+func (c *ClusterController) imagePrefix() string {
+	if c.config.Registry != "" {
+		return fmt.Sprintf("%s/", c.config.Registry)
+	}
+	return ""
+}
+
 // Setup sets up a test cluster with the given configuration
 func (c *ClusterController) Setup() console.ErrorStatus {
 	c.status.Start("Setting up Atomix controller")

--- a/pkg/runner/config.go
+++ b/pkg/runner/config.go
@@ -31,6 +31,7 @@ var (
 
 // ClusterConfig provides the configuration for the Kubernetes test cluster
 type ClusterConfig struct {
+	Registry      string `yaml:"registry" mapstructure:"registry"`
 	Preset        string `yaml:"preset" mapstructure:"preset"`
 	ConfigNodes   int    `yaml:"configNodes" mapstructure:"topoNodes"`
 	TopoNodes     int    `yaml:"topoNodes" mapstructure:"topoNodes"`

--- a/pkg/runner/network.go
+++ b/pkg/runner/network.go
@@ -127,7 +127,7 @@ func (c *ClusterController) createNetworkPod(name string, config *NetworkConfig)
 			Containers: []corev1.Container{
 				{
 					Name:            "stratum-simulator",
-					Image:           "opennetworking/mn-stratum",
+					Image:           c.imageName("opennetworking/mn-stratum"),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Stdin:           true,
 					Args:            config.MininetOptions,

--- a/pkg/runner/onos-config.go
+++ b/pkg/runner/onos-config.go
@@ -245,7 +245,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 					Containers: []corev1.Container{
 						{
 							Name:            "onos-config",
-							Image:           "onosproject/onos-config:debug",
+							Image:           c.imageName("onosproject/onos-config:debug"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/runner/onos-topo.go
+++ b/pkg/runner/onos-topo.go
@@ -117,7 +117,7 @@ func (c *ClusterController) createOnosTopoDeployment() error {
 					Containers: []corev1.Container{
 						{
 							Name:            "onos-topo",
-							Image:           "onosproject/onos-topo:debug",
+							Image:           c.imageName("onosproject/onos-topo:debug"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/runner/simulator.go
+++ b/pkg/runner/simulator.go
@@ -96,7 +96,7 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 			Containers: []corev1.Container{
 				{
 					Name:            "onos-device-simulator",
-					Image:           "onosproject/device-simulator:latest",
+					Image:           c.imageName("onosproject/device-simulator:latest"),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Ports: []corev1.ContainerPort{
 						{

--- a/pkg/runner/test.go
+++ b/pkg/runner/test.go
@@ -95,7 +95,7 @@ func (c *ClusterController) createTestJob(testID string, args []string, timeout 
 					Containers: []corev1.Container{
 						{
 							Name:            "test",
-							Image:           "onosproject/onos-tests:latest",
+							Image:           c.imageName("onosproject/onos-tests:latest"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args:            args,
 							Env: []corev1.EnvVar{


### PR DESCRIPTION
This PR adds a `--docker-registry` option to the `create cluster` command. When a Docker registry host:port is provided, all image names are prefixed with the registry location.

To address issue #15 