### PR TITLE
Add Atomix primitive tests

### DIFF
--- a/test/atomix/listtest.go
+++ b/test/atomix/listtest.go
@@ -15,9 +15,7 @@
 package atomix
 
 import (
-	"bytes"
 	"context"
-	atomixmap "github.com/atomix/atomix-go-client/pkg/client/map_"
 	"github.com/atomix/atomix-go-client/pkg/client/session"
 	"github.com/onosproject/onos-test/pkg/runner"
 	"github.com/onosproject/onos-test/test"
@@ -27,56 +25,63 @@ import (
 	"time"
 )
 
-func TestAtomixMap(t *testing.T) {
-	client, err := env.NewAtomixClient("map")
+func TestAtomixList(t *testing.T) {
+	client, err := env.NewAtomixClient("list")
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 
 	group, err := client.GetGroup(context.Background(), "raft")
 	assert.NoError(t, err)
 
-	map_, err := group.GetMap(context.Background(), "test", session.WithTimeout(5*time.Second))
+	list, err := group.GetList(context.Background(), "test", session.WithTimeout(5*time.Second))
 	assert.NoError(t, err)
 
-	size, err := map_.Size(context.Background())
+	size, err := list.Size(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 0, size)
 
-	value, err := map_.Get(context.Background(), "foo")
+	err = list.Append(context.Background(), "Hello world!")
 	assert.NoError(t, err)
-	assert.Nil(t, value)
 
-	value, err = map_.Put(context.Background(), "foo", []byte("Hello world!"))
-	assert.NoError(t, err)
-	assert.NotNil(t, value)
-	assert.Equal(t, "foo", value.Key)
-	assert.True(t, bytes.Equal([]byte("Hello world!"), value.Value))
-	assert.NotEqual(t, int64(0), value.Version)
-	version := value.Version
-
-	value, err = map_.Get(context.Background(), "foo")
-	assert.NoError(t, err)
-	assert.NotNil(t, value)
-	assert.Equal(t, "foo", value.Key)
-	assert.True(t, bytes.Equal([]byte("Hello world!"), value.Value))
-	assert.Equal(t, version, value.Version)
-
-	size, err = map_.Size(context.Background())
+	size, err = list.Size(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, size)
 
-	ch := make(chan *atomixmap.KeyValue)
-	err = map_.Entries(context.Background(), ch)
+	value, err := list.Get(context.Background(), 0)
 	assert.NoError(t, err)
+	assert.Equal(t, "Hello world!", value)
+
+	value, err = list.Remove(context.Background(), 0)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello world!", value)
+
+	size, err = list.Size(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, size)
+
+	err = list.Append(context.Background(), "Hello world!")
+	assert.NoError(t, err)
+
+	err = list.Append(context.Background(), "Hello world again!")
+	assert.NoError(t, err)
+
+	ch := make(chan string)
+	err = list.Items(context.Background(), ch)
 	i := 0
-	for kv := range ch {
-		assert.Equal(t, "foo", kv.Key)
-		assert.Equal(t, "Hello world!", string(kv.Value))
-		i++
+	for value := range ch {
+		if i == 0 {
+			assert.Equal(t, "Hello world!", value)
+			i++
+		} else if i == 1 {
+			assert.Equal(t, "Hello world again!", value)
+			i++
+		} else {
+			assert.Fail(t, "Too many values")
+		}
 	}
-	assert.Equal(t, 1, i)
+	assert.NoError(t, err)
 }
 
 func init() {
-	test.Registry.RegisterTest("atomix-map", TestAtomixMap, []*runner.TestSuite{AtomixTests})
+	test.Registry.RegisterTest("atomix-list", TestAtomixList, []*runner.TestSuite{AtomixTests})
 }

--- a/test/atomix/locktest.go
+++ b/test/atomix/locktest.go
@@ -1,0 +1,112 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package atomix
+
+import (
+	"context"
+	atomixlock "github.com/atomix/atomix-go-client/pkg/client/lock"
+	"github.com/atomix/atomix-go-client/pkg/client/session"
+	"github.com/onosproject/onos-test/pkg/runner"
+	"github.com/onosproject/onos-test/test"
+	"github.com/onosproject/onos-test/test/env"
+	"github.com/stretchr/testify/assert"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAtomixLock(t *testing.T) {
+	client, err := env.NewAtomixClient("lock")
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+
+	group, err := client.GetGroup(context.Background(), "raft")
+	assert.NoError(t, err)
+
+	lock1, err := group.GetLock(context.Background(), "test", session.WithTimeout(5*time.Second))
+	assert.NoError(t, err)
+
+	lock2, err := group.GetLock(context.Background(), "test", session.WithTimeout(5*time.Second))
+	assert.NoError(t, err)
+
+	id, err := lock1.Lock(context.Background())
+	assert.NoError(t, err)
+	assert.NotEqual(t, uint64(0), id)
+
+	var lock uint64
+	wait := make(chan struct{})
+	go func() {
+		id, err := lock2.Lock(context.Background())
+		assert.NoError(t, err)
+		assert.NotEqual(t, uint64(0), id)
+		atomic.StoreUint64(&lock, id)
+		wait <- struct{}{}
+	}()
+
+	isLocked, err := lock1.IsLocked(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, isLocked)
+
+	isLocked, err = lock1.IsLocked(context.Background(), atomixlock.WithIsVersion(id))
+	assert.NoError(t, err)
+	assert.True(t, isLocked)
+
+	isLocked, err = lock1.IsLocked(context.Background(), atomixlock.WithIsVersion(id+1))
+	assert.NoError(t, err)
+	assert.False(t, isLocked)
+
+	unlocked, err := lock1.Unlock(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, unlocked)
+
+	<-wait
+
+	id = atomic.LoadUint64(&lock)
+	assert.NotEqual(t, uint64(0), id)
+
+	isLocked, err = lock2.IsLocked(context.Background())
+	assert.NoError(t, err)
+	assert.True(t, isLocked)
+
+	unlocked, err = lock1.Unlock(context.Background(), atomixlock.WithVersion(id))
+	assert.NoError(t, err)
+	assert.True(t, unlocked)
+
+	isLocked, err = lock2.IsLocked(context.Background())
+	assert.NoError(t, err)
+	assert.False(t, isLocked)
+
+	id, err = lock1.Lock(context.Background())
+	assert.NoError(t, err)
+	assert.NotEqual(t, uint64(0), id)
+
+	lock = 0
+	wait = make(chan struct{})
+	go func() {
+		id, err := lock2.Lock(context.Background(), atomixlock.WithTimeout(100*time.Millisecond))
+		assert.NoError(t, err)
+		atomic.StoreUint64(&lock, id)
+		wait <- struct{}{}
+	}()
+
+	<-wait
+
+	id = atomic.LoadUint64(&lock)
+	assert.Equal(t, uint64(0), id)
+}
+
+func init() {
+	test.Registry.RegisterTest("atomix-lock", TestAtomixLock, []*runner.TestSuite{AtomixTests})
+}

--- a/test/atomix/maptest.go
+++ b/test/atomix/maptest.go
@@ -35,18 +35,18 @@ func TestAtomixMap(t *testing.T) {
 	group, err := client.GetGroup(context.Background(), "raft")
 	assert.NoError(t, err)
 
-	map_, err := group.GetMap(context.Background(), "test", session.WithTimeout(5*time.Second))
+	m, err := group.GetMap(context.Background(), "test", session.WithTimeout(5*time.Second))
 	assert.NoError(t, err)
 
-	size, err := map_.Size(context.Background())
+	size, err := m.Size(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 0, size)
 
-	value, err := map_.Get(context.Background(), "foo")
+	value, err := m.Get(context.Background(), "foo")
 	assert.NoError(t, err)
 	assert.Nil(t, value)
 
-	value, err = map_.Put(context.Background(), "foo", []byte("Hello world!"))
+	value, err = m.Put(context.Background(), "foo", []byte("Hello world!"))
 	assert.NoError(t, err)
 	assert.NotNil(t, value)
 	assert.Equal(t, "foo", value.Key)
@@ -54,19 +54,19 @@ func TestAtomixMap(t *testing.T) {
 	assert.NotEqual(t, int64(0), value.Version)
 	version := value.Version
 
-	value, err = map_.Get(context.Background(), "foo")
+	value, err = m.Get(context.Background(), "foo")
 	assert.NoError(t, err)
 	assert.NotNil(t, value)
 	assert.Equal(t, "foo", value.Key)
 	assert.True(t, bytes.Equal([]byte("Hello world!"), value.Value))
 	assert.Equal(t, version, value.Version)
 
-	size, err = map_.Size(context.Background())
+	size, err = m.Size(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, size)
 
 	ch := make(chan *atomixmap.KeyValue)
-	err = map_.Entries(context.Background(), ch)
+	err = m.Entries(context.Background(), ch)
 	assert.NoError(t, err)
 	i := 0
 	for kv := range ch {

--- a/test/atomix/maptest.go
+++ b/test/atomix/maptest.go
@@ -31,25 +31,20 @@ func TestAtomixMap(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, client)
 
-	println("1")
 	group, err := client.GetGroup(context.Background(), "raft")
 	assert.NoError(t, err)
 
-	println("2")
 	map_, err := group.GetMap(context.Background(), "test", session.WithTimeout(5 * time.Second))
 	assert.NoError(t, err)
 
-	println("3")
 	size, err := map_.Size(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 0, size)
 
-	println("4")
 	value, err := map_.Get(context.Background(), "foo")
 	assert.NoError(t, err)
 	assert.Nil(t, value)
 
-	println("5")
 	value, err = map_.Put(context.Background(), "foo", []byte("Hello world!"))
 	assert.NoError(t, err)
 	assert.NotNil(t, value)


### PR DESCRIPTION
This PR is a first pass at adding distributed primitive tests to the test suite. It ensures primitives are working end-to-end and primitive operations are implemented correctly for stores. The tests are placed in onos-test for convenience, to be able to reuse the `onit` work that's already been done.

These tests are a work in progress. Some changes in the primitives need to be released to DockerHub before this can be merged.