### PR TITLE
Initialize onit configuration lazily

### DIFF
--- a/pkg/onit/cli/config.go
+++ b/pkg/onit/cli/config.go
@@ -119,9 +119,4 @@ func init() {
 	viper.AddConfigPath(home + "/.onos")
 	viper.AddConfigPath("/etc/onos")
 	viper.AddConfigPath(".")
-
-	err = viper.ReadInConfig()
-	if err != nil {
-		exitError(err)
-	}
 }


### PR DESCRIPTION
onit should not fail when no configuration is found. The configuration should be initialized when a configuration value is stored for the first time.