### PR TITLE
give a name (itests) to the cluster for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ license_check: # @HELP examine and ensure license headers exist
 
 # integration: @HELP build and run integration tests
 integration: kind
-	onit create cluster
+	onit create cluster itests
 	onit add simulator
 	onit add simulator
 	onit run suite integration-tests


### PR DESCRIPTION
To run kubctl commands easily, it would be better to give a predefined name when we create a cluster for integration tests. 