### PR TITLE
Remove dependency on k8s templating to avoid dependency conflicts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,10 +17,9 @@ require (
 	github.com/stretchr/testify v1.3.0
 	google.golang.org/grpc v1.21.1
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
-	k8s.io/api v0.0.0-20190802060718-d0d4f3afa3ab
+	k8s.io/api v0.0.0-20190620073856-dcce3486da33
 	k8s.io/apiextensions-apiserver v0.0.0-20190325193600-475668423e9f
-	k8s.io/apimachinery v0.0.0-20190802060556-6fa4771c83b3
-	k8s.io/client-go v0.0.0-20190802021151-fdb3fbe99e1d
+	k8s.io/apimachinery v0.0.0-20190620073744-d16981aedf33
+	k8s.io/client-go v0.0.0-20190620074045-585a16d2e773
 	k8s.io/klog v0.3.3
-	k8s.io/kubectl v0.0.0-20190803022817-1937123dfffc
 )

--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -17,20 +17,17 @@ package cli
 import (
 	"fmt"
 
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/spf13/cobra"
 )
 
 var (
-	addExample = templates.Examples(i18n.T(`
+	addExample = `
             # To add a simulator with a given name:
 			onit add simulator simulator-1
 
 			# To add a network of stratum switches that emulates a linear network topology with two nodes:
-			onit add network stratum-linear -- --topo linear,2`))
+			onit add network stratum-linear -- --topo linear,2`
 )
 
 // getAddCommand returns a cobra "add" command for adding resources to the cluster

--- a/pkg/onit/cli/cli.go
+++ b/pkg/onit/cli/cli.go
@@ -16,9 +16,8 @@ package cli
 
 import (
 	"fmt"
-	"os"
-
 	"github.com/onosproject/onos-test/pkg/runner"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/onosproject/onos-test/pkg/onit/console"

--- a/pkg/onit/cli/create.go
+++ b/pkg/onit/cli/create.go
@@ -19,12 +19,10 @@ import (
 
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
 )
 
 var (
-	createExample = templates.Examples(i18n.T(`
+	createExample = `
             # To create a cluster with a given name that contains one instance of each subsystem (e.g. onos-config, onos-topo): 
 			onit create cluster onit-cluster-1 
 
@@ -35,7 +33,7 @@ var (
 			onit create cluster --partitions 2 
 
 			# To create a cluster that fetches docker images from a private docker registry:
-			onit create cluster --docker-registry <host>:<port>`))
+			onit create cluster --docker-registry <host>:<port>`
 )
 
 // getCreateCommand returns a cobra "setup" command for setting up resources

--- a/pkg/onit/cli/debug.go
+++ b/pkg/onit/cli/debug.go
@@ -17,19 +17,14 @@ package cli
 import (
 	"fmt"
 
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/spf13/cobra"
 )
 
 var (
-	debugExample = templates.Examples(i18n.T(` 
+	debugExample = ` 
     # To debug a node in the cluster:
-    onit debug <name of a node>
-
-`))
+    onit debug <name of a node>`
 )
 
 // getDebugCommand returns a cobra "debug" command to open a debugger port to the given resource

--- a/pkg/onit/cli/delete.go
+++ b/pkg/onit/cli/delete.go
@@ -17,17 +17,15 @@ package cli
 import (
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/spf13/cobra"
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
 )
 
 var (
-	deleteExample = templates.Examples(i18n.T(`
+	deleteExample = `
             # To delete a cluster with a given name:
 			onit delete cluster <name of cluster>
 
 			# To delete the default cluster:
-			onit delete cluster`))
+			onit delete cluster`
 )
 
 // getDeleteCommand returns a cobra "teardown" command for tearing down Kubernetes test resources

--- a/pkg/onit/cli/fetch.go
+++ b/pkg/onit/cli/fetch.go
@@ -18,22 +18,18 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/onosproject/onos-test/pkg/onit/console"
 	"github.com/spf13/cobra"
 )
 
 var (
-	fetchExample = templates.Examples(i18n.T(`
+	fetchExample = `
                     # To download logs from all nodes
                     onit fetch logs 
                     
                     # To download logs from a node
-                    onit fetch logs <name of the node>
-`))
+                    onit fetch logs <name of the node>`
 )
 
 // getFetchCommand returns a cobra "download" command for downloading resources from a test cluster

--- a/pkg/onit/cli/get.go
+++ b/pkg/onit/cli/get.go
@@ -23,9 +23,6 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/onosproject/onos-test/pkg/runner"
 	"github.com/spf13/cobra"
@@ -33,7 +30,7 @@ import (
 )
 
 var (
-	getExample = templates.Examples(i18n.T(` 
+	getExample = ` 
             # Get current Cluster:
             onit get cluster
 
@@ -65,9 +62,7 @@ var (
             onit get logs <name of resource>
             
             # Get the history of test runs
-            onit get history
-
-	`))
+            onit get history`
 )
 
 // getGetCommand returns a cobra "get" command to read test configurations

--- a/pkg/onit/cli/remove.go
+++ b/pkg/onit/cli/remove.go
@@ -17,20 +17,17 @@ package cli
 import (
 	"errors"
 
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/spf13/cobra"
 )
 
 var (
-	removeExample = templates.Examples(i18n.T(`
+	removeExample = `
             # To remove a simulator with a given name:
 			onit remove simulator <simulator-name>
 
 			# To remove a network with a given name:
-			onit remove network <network-name>`))
+			onit remove network <network-name>`
 )
 
 // getRemoveCommand returns a cobra "remove" command for removing resources from the cluster

--- a/pkg/onit/cli/run.go
+++ b/pkg/onit/cli/run.go
@@ -19,23 +19,18 @@ import (
 	"os"
 	"time"
 
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/onosproject/onos-test/pkg/runner"
 	"github.com/spf13/cobra"
 )
 
 var (
-	runExample = templates.Examples(i18n.T(`
+	runExample = `
     # To run all integration tests:
     onit run suite
 
     # To run a single test on a cluster
-    onit run test <name of a test>
-
-`))
+    onit run test <name of a test>`
 )
 
 // getRunCommand returns a cobra run command to run integration tests

--- a/pkg/onit/cli/set.go
+++ b/pkg/onit/cli/set.go
@@ -17,18 +17,14 @@ package cli
 import (
 	"fmt"
 
-	"k8s.io/kubectl/pkg/util/i18n"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/onosproject/onos-test/pkg/onit"
 	"github.com/spf13/cobra"
 )
 
 var (
-	setExample = templates.Examples(i18n.T(` 
+	setExample = ` 
     # To change current cluster to another cluster
-    onit set cluster <name of a cluster>
-`))
+    onit set cluster <name of a cluster>`
 )
 
 // getSetCommand returns a cobra "set" command for setting configurations


### PR DESCRIPTION
Fixes the build. Removes the dependency on k8s templating to avoid the logger conflict. The output is basically the same, just not i18n which is fine for our purposes.