### PR TITLE
Implement a command to add an app to an onit cluster

### DIFF
--- a/pkg/onit/app.go
+++ b/pkg/onit/app.go
@@ -1,0 +1,221 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package onit
+
+import (
+	"encoding/json"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// GetSApps returns a list of apps deployed in the cluster
+func (c *ClusterController) GetApps() ([]string, error) {
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: "type=app",
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	apps := make([]string, len(pods.Items))
+	for i, pod := range pods.Items {
+		apps[i] = pod.Name
+	}
+	return apps, nil
+}
+
+// setupApp creates an app
+func (c *ClusterController) setupApp(name string, config *AppConfig) error {
+	if err := c.createAppConfigMap(name, config); err != nil {
+		return err
+	}
+	if err := c.createAppPod(name); err != nil {
+		return err
+	}
+	if err := c.createAppService(name); err != nil {
+		return err
+	}
+	if err := c.awaitAppReady(name); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createAppConfigMap creates an app configuration
+func (c *ClusterController) createAppConfigMap(name string, config *AppConfig) error {
+	configObj, err := config.load()
+	if err != nil {
+		return err
+	}
+	configJSON, err := json.Marshal(configObj)
+	if err != nil {
+		return err
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.clusterID,
+		},
+		Data: map[string]string{
+			"config.json": string(configJSON),
+		},
+	}
+	_, err = c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Create(cm)
+	return err
+}
+
+// createAppPod creates an app pod
+func (c *ClusterController) createAppPod(name string) error {
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.clusterID,
+			Labels: map[string]string{
+				"type": "app",
+				"app":  name,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					// TODO: pull in the image name from the command arguments
+					Image:           c.imageName("onosproject/onos-ztp", "latest"),
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "gnmi",
+							ContainerPort: 5150,
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.FromInt(5150),
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       10,
+					},
+					LivenessProbe: &corev1.Probe{
+						Handler: corev1.Handler{
+							TCPSocket: &corev1.TCPSocketAction{
+								Port: intstr.FromInt(5150),
+							},
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       20,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "config",
+							MountPath: "/etc/app/configs",
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: name,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := c.kubeclient.CoreV1().Pods(c.clusterID).Create(pod)
+	return err
+}
+
+// createAppService creates an app service
+func (c *ClusterController) createAppService(name string) error {
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: c.clusterID,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": name,
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name: "gnmi",
+					Port: 5150,
+				},
+			},
+		},
+	}
+
+	_, err := c.kubeclient.CoreV1().Services(c.clusterID).Create(service)
+	return err
+}
+
+// awaitAppReady waits for the given app to complete startup
+func (c *ClusterController) awaitAppReady(name string) error {
+	for {
+		pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		} else if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
+			return nil
+		} else {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+}
+
+// teardownApp tears down a app by name
+func (c *ClusterController) teardownApp(name string) error {
+	var err error
+	if e := c.deleteAppPod(name); e != nil {
+		err = e
+	}
+	if e := c.deleteAppService(name); e != nil {
+		err = e
+	}
+	if e := c.deleteAppConfigMap(name); e != nil {
+		err = e
+	}
+	return err
+}
+
+// deleteAppConfigMap deletes an app ConfigMap by name
+func (c *ClusterController) deleteAppConfigMap(name string) error {
+	return c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Delete(name, &metav1.DeleteOptions{})
+}
+
+// deleteAppPod deletes an app Pod by name
+func (c *ClusterController) deleteAppPod(name string) error {
+	return c.kubeclient.CoreV1().Pods(c.clusterID).Delete(name, &metav1.DeleteOptions{})
+}
+
+// deleteAppService deletes an app Service by name
+func (c *ClusterController) deleteAppService(name string) error {
+	return c.kubeclient.CoreV1().Services(c.clusterID).Delete(name, &metav1.DeleteOptions{})
+}

--- a/pkg/onit/app.go
+++ b/pkg/onit/app.go
@@ -48,7 +48,7 @@ func (c *ClusterController) setupApp(name string, config *AppConfig) error {
 	if err := c.createAppService(name); err != nil {
 		return err
 	}
-	if err := c.createOnosAppDeployment(name); err != nil {
+	if err := c.createOnosAppDeployment(name, config.Image); err != nil {
 		return err
 	}
 	if err := c.awaitOnosAppDeploymentReady(name); err != nil {
@@ -71,7 +71,7 @@ func (c *ClusterController) createAppConfigMap(name string, config *AppConfig) e
 }
 
 // createOnosAppDeployment creates an app Deployment
-func (c *ClusterController) createOnosAppDeployment(name string) error {
+func (c *ClusterController) createOnosAppDeployment(name string, image string) error {
 	nodes := int32(1) //int32(c.config.TopoNodes)
 	zero := int64(0)
 	dep := &appsv1.Deployment{
@@ -102,7 +102,7 @@ func (c *ClusterController) createOnosAppDeployment(name string) error {
 					Containers: []corev1.Container{
 						{
 							Name:            name,
-							Image:           c.imageName("onosproject/onos-ztp", "latest"),
+							Image:           c.imageName(image, "latest"),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Env: []corev1.EnvVar{
 								{

--- a/pkg/onit/app.go
+++ b/pkg/onit/app.go
@@ -15,12 +15,12 @@
 package onit
 
 import (
-	"encoding/json"
-	"time"
-
+	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"time"
 )
 
 // GetSApps returns a list of apps deployed in the cluster
@@ -45,13 +45,13 @@ func (c *ClusterController) setupApp(name string, config *AppConfig) error {
 	if err := c.createAppConfigMap(name, config); err != nil {
 		return err
 	}
-	if err := c.createAppPod(name); err != nil {
-		return err
-	}
 	if err := c.createAppService(name); err != nil {
 		return err
 	}
-	if err := c.awaitAppReady(name); err != nil {
+	if err := c.createOnosAppDeployment(name); err != nil {
+		return err
+	}
+	if err := c.awaitOnosAppDeploymentReady(name); err != nil {
 		return err
 	}
 	return nil
@@ -59,86 +59,144 @@ func (c *ClusterController) setupApp(name string, config *AppConfig) error {
 
 // createAppConfigMap creates an app configuration
 func (c *ClusterController) createAppConfigMap(name string, config *AppConfig) error {
-	configObj, err := config.load()
-	if err != nil {
-		return err
-	}
-	configJSON, err := json.Marshal(configObj)
-	if err != nil {
-		return err
-	}
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: c.clusterID,
 		},
-		Data: map[string]string{
-			"config.json": string(configJSON),
-		},
+		Data: map[string]string{},
 	}
-	_, err = c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Create(cm)
+	_, err := c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Create(cm)
 	return err
 }
 
-// createAppPod creates an app pod
-func (c *ClusterController) createAppPod(name string) error {
-
-	pod := &corev1.Pod{
+// createOnosAppDeployment creates an app Deployment
+func (c *ClusterController) createOnosAppDeployment(name string) error {
+	nodes := int32(1) //int32(c.config.TopoNodes)
+	zero := int64(0)
+	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: c.clusterID,
-			Labels: map[string]string{
-				"type": "app",
-				"app":  name,
-			},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name: "app",
-					// TODO: pull in the image name from the command arguments
-					Image:           c.imageName("onosproject/onos-ztp", "latest"),
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Ports: []corev1.ContainerPort{
-						{
-							Name:          "gnmi",
-							ContainerPort: 5150,
-						},
-					},
-					ReadinessProbe: &corev1.Probe{
-						Handler: corev1.Handler{
-							TCPSocket: &corev1.TCPSocketAction{
-								Port: intstr.FromInt(5150),
-							},
-						},
-						InitialDelaySeconds: 5,
-						PeriodSeconds:       10,
-					},
-					LivenessProbe: &corev1.Probe{
-						Handler: corev1.Handler{
-							TCPSocket: &corev1.TCPSocketAction{
-								Port: intstr.FromInt(5150),
-							},
-						},
-						InitialDelaySeconds: 15,
-						PeriodSeconds:       20,
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "config",
-							MountPath: "/etc/app/configs",
-							ReadOnly:  true,
-						},
-					},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &nodes,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":  "onos",
+					"type": "app",
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "config",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: name,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app":      "onos",
+						"type":     "app",
+						"resource": name,
+					},
+					Annotations: map[string]string{
+						"seccomp.security.alpha.kubernetes.io/pod": "unconfined",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:            name,
+							Image:           c.imageName("onosproject/onos-ztp", "latest"),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ATOMIX_CONTROLLER",
+									Value: fmt.Sprintf("atomix-controller.%s.svc.cluster.local:5679", c.clusterID),
+								},
+								{
+									Name:  "ATOMIX_APP",
+									Value: "test",
+								},
+								{
+									Name:  "ATOMIX_NAMESPACE",
+									Value: c.clusterID,
+								},
+								{
+									Name:  "ATOMIX_RAFT_GROUP",
+									Value: "raft",
+								},
+							},
+							Args: []string{
+								"-caPath=/etc/app/certs/onf.cacrt",
+								"-keyPath=/etc/app/certs/onos-config.key",
+								"-certPath=/etc/app/certs/onos-config.crt",
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "grpc",
+									ContainerPort: 5150,
+								},
+								{
+									Name:          "debug",
+									ContainerPort: 40000,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(5150),
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       10,
+							},
+							LivenessProbe: &corev1.Probe{
+								Handler: corev1.Handler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(5150),
+									},
+								},
+								InitialDelaySeconds: 15,
+								PeriodSeconds:       20,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "app",
+									MountPath: "/etc/app/configs",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "secret",
+									MountPath: "/etc/app/certs",
+									ReadOnly:  true,
+								},
+							},
+							SecurityContext: &corev1.SecurityContext{
+								Capabilities: &corev1.Capabilities{
+									Add: []corev1.Capability{
+										"SYS_PTRACE",
+									},
+								},
+							},
+						},
+					},
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: &zero,
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "app",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: name,
+									},
+								},
+							},
+						},
+						{
+							Name: "secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: c.clusterID,
+								},
 							},
 						},
 					},
@@ -146,8 +204,7 @@ func (c *ClusterController) createAppPod(name string) error {
 			},
 		},
 	}
-
-	_, err := c.kubeclient.CoreV1().Pods(c.clusterID).Create(pod)
+	_, err := c.kubeclient.AppsV1().Deployments(c.clusterID).Create(dep)
 	return err
 }
 
@@ -176,24 +233,27 @@ func (c *ClusterController) createAppService(name string) error {
 	return err
 }
 
-// awaitAppReady waits for the given app to complete startup
-func (c *ClusterController) awaitAppReady(name string) error {
+// awaitOnosAppDeploymentReady waits for the app pods to complete startup
+func (c *ClusterController) awaitOnosAppDeploymentReady(name string) error {
 	for {
-		pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(name, metav1.GetOptions{})
+		// Get the app deployment
+		dep, err := c.kubeclient.AppsV1().Deployments(c.clusterID).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return err
-		} else if len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
-			return nil
-		} else {
-			time.Sleep(100 * time.Millisecond)
 		}
+
+		// Return once the all replicas in the deployment are ready
+		if int(dep.Status.ReadyReplicas) == c.config.ConfigNodes {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 
 // teardownApp tears down a app by name
 func (c *ClusterController) teardownApp(name string) error {
 	var err error
-	if e := c.deleteAppPod(name); e != nil {
+	if e := c.deleteAppDeployment(name); e != nil {
 		err = e
 	}
 	if e := c.deleteAppService(name); e != nil {
@@ -211,8 +271,8 @@ func (c *ClusterController) deleteAppConfigMap(name string) error {
 }
 
 // deleteAppPod deletes an app Pod by name
-func (c *ClusterController) deleteAppPod(name string) error {
-	return c.kubeclient.CoreV1().Pods(c.clusterID).Delete(name, &metav1.DeleteOptions{})
+func (c *ClusterController) deleteAppDeployment(name string) error {
+	return c.kubeclient.AppsV1().Deployments(c.clusterID).Delete(name, &metav1.DeleteOptions{})
 }
 
 // deleteAppService deletes an app Service by name

--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -204,8 +204,9 @@ func getAddAppCommand() *cobra.Command {
 			}
 
 			// Create the app configuration
+			imageName := args[0]
 			config := &onit.AppConfig{
-				Image: args[0],
+				Image: imageName,
 			}
 
 			// Add the app to the cluster

--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -204,7 +204,9 @@ func getAddAppCommand() *cobra.Command {
 			}
 
 			// Create the app configuration
-			config := &onit.AppConfig{}
+			config := &onit.AppConfig{
+				Image: args[0],
+			}
 
 			// Add the app to the cluster
 			if status := cluster.AddApp(name, config); status.Failed() {

--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -203,10 +203,10 @@ func getAddAppCommand() *cobra.Command {
 				exitError(err)
 			}
 
-			// Create the simulator configuration
+			// Create the app configuration
 			config := &onit.AppConfig{}
 
-			// Add the simulator to the cluster
+			// Add the app to the cluster
 			if status := cluster.AddApp(name, config); status.Failed() {
 				exitStatus(status)
 			} else {

--- a/pkg/onit/cli/get.go
+++ b/pkg/onit/cli/get.go
@@ -354,7 +354,6 @@ func getGetAppsCommand() *cobra.Command {
 	return cmd
 }
 
-
 // getGetPartitionCommand returns a cobra command to get the nodes in a partition
 func getGetPartitionCommand() *cobra.Command {
 	cmd := &cobra.Command{

--- a/pkg/onit/cli/remove.go
+++ b/pkg/onit/cli/remove.go
@@ -27,7 +27,10 @@ var (
 		onit remove simulator <simulator-name>
 
 		# Remove a network with a given name
-		onit remove network <network-name>`
+		onit remove network <network-name>
+	
+		# Remove an app
+		onit remove app <app-name>`
 )
 
 // getRemoveCommand returns a cobra "remove" command for removing resources from the cluster
@@ -175,7 +178,7 @@ func getRemoveAppCommand() *cobra.Command {
 			}
 
 			if !Contains(apps, name) {
-				exitError(errors.New("The given simulator name does not exist"))
+				exitError(errors.New("the given app name does not exist"))
 			}
 
 			// Remove the app from the cluster

--- a/pkg/onit/cluster.go
+++ b/pkg/onit/cluster.go
@@ -243,6 +243,15 @@ func (c *ClusterController) AddSimulator(name string, config *SimulatorConfig) c
 	return c.status.Succeed()
 }
 
+// AddApp adds a device simulator with the given configuration
+func (c *ClusterController) AddApp(name string, config *AppConfig) console.ErrorStatus {
+	c.status.Start("Setting up app")
+	if err := c.setupApp(name, config); err != nil {
+		return c.status.Fail(err)
+	}
+	return c.status.Succeed()
+}
+
 // AddNetwork adds a stratum network with the given configuration
 func (c *ClusterController) AddNetwork(name string, config *NetworkConfig) console.ErrorStatus {
 	c.status.Start("Setting up network")
@@ -470,6 +479,15 @@ func (c *ClusterController) RemoveNetwork(name string) console.ErrorStatus {
 	c.status.Start("Reconfiguring onos-config nodes")
 	if err := c.removeNetworkFromConfig(name, configMaps); err != nil {
 		return c.status.Fail(err)
+	}
+	return c.status.Succeed()
+}
+
+// RemoveApp removes an app with the given name
+func (c *ClusterController) RemoveApp(name string) console.ErrorStatus {
+	c.status.Start("Tearing down app")
+	if err := c.teardownApp(name); err != nil {
+		c.status.Fail(err)
 	}
 	return c.status.Succeed()
 }

--- a/pkg/onit/common.go
+++ b/pkg/onit/common.go
@@ -47,7 +47,7 @@ const (
 	// OnosTopo type of node is topo
 	OnosTopo NodeType = "topo"
 
-	// OnosTopo type of node is app
+	// OnosApp type of node is app
 	OnosApp NodeType = "app"
 
 	// OnosAll type of node is all

--- a/pkg/onit/common.go
+++ b/pkg/onit/common.go
@@ -47,6 +47,9 @@ const (
 	// OnosTopo type of node is topo
 	OnosTopo NodeType = "topo"
 
+	// OnosTopo type of node is app
+	OnosApp NodeType = "app"
+
 	// OnosAll type of node is all
 	OnosAll NodeType = "all"
 )

--- a/pkg/onit/config.go
+++ b/pkg/onit/config.go
@@ -68,6 +68,7 @@ type SimulatorConfig struct {
 
 // AppConfig provides the configuration for an app
 type AppConfig struct {
+	Image string
 }
 
 // NetworkConfig provides the configuration for a stratum network
@@ -94,11 +95,4 @@ func (c *SimulatorConfig) load() (map[string]interface{}, error) {
 	var jsonObj map[string]interface{}
 	err = json.Unmarshal(jsonBytes, &jsonObj)
 	return jsonObj, err
-}
-
-// load loads an app configuration
-func (c *AppConfig) load() (map[string]interface{}, error) {
-	//  noop for now
-	var jsonObj map[string]interface{}
-	return jsonObj, nil
 }

--- a/pkg/onit/config.go
+++ b/pkg/onit/config.go
@@ -66,6 +66,10 @@ type SimulatorConfig struct {
 	Config string `yaml:"config" mapstructure:"config"`
 }
 
+// AppConfig provides the configuration for an app
+type AppConfig struct {
+}
+
 // NetworkConfig provides the configuration for a stratum network
 type NetworkConfig struct {
 	Config         string `yaml:"config" mapstructure:"config"`
@@ -90,4 +94,11 @@ func (c *SimulatorConfig) load() (map[string]interface{}, error) {
 	var jsonObj map[string]interface{}
 	err = json.Unmarshal(jsonBytes, &jsonObj)
 	return jsonObj, err
+}
+
+// load loads an app configuration
+func (c *AppConfig) load() (map[string]interface{}, error) {
+	//  noop for now
+	var jsonObj map[string]interface{}
+	return jsonObj, nil
 }


### PR DESCRIPTION
This PR implements a command to add an app to an onit cluster. You can invoke it like this:

onit add app onosproject/onos-ztp

where onosproject/onoa-ztp is the name of a docker image available on the cluster.