### PR TITLE
Use onos topo service commands to add devices to running clusters

### DIFF
--- a/pkg/onit/cluster.go
+++ b/pkg/onit/cluster.go
@@ -253,8 +253,8 @@ func (c *ClusterController) AddSimulator(name string, config *SimulatorConfig) c
 	if err := c.setupSimulator(name, config); err != nil {
 		return c.status.Fail(err)
 	}
-	c.status.Start("Reconfiguring onos-config nodes")
-	if err := c.addSimulatorToConfig(name); err != nil {
+	c.status.Start("Adding simulator to topo")
+	if err := c.addSimulatorToTopo(name); err != nil {
 		return c.status.Fail(err)
 	}
 	return c.status.Succeed()
@@ -275,8 +275,8 @@ func (c *ClusterController) AddNetwork(name string, config *NetworkConfig) conso
 	if err := c.setupNetwork(name, config); err != nil {
 		return c.status.Fail(err)
 	}
-	c.status.Start("Reconfiguring onos-config nodes")
-	if err := c.addNetworkToConfig(name, config); err != nil {
+	c.status.Start("Adding network to topo")
+	if err := c.addNetworkToTopo(name, config); err != nil {
 		return c.status.Fail(err)
 	}
 	return c.status.Succeed()

--- a/pkg/onit/cluster.go
+++ b/pkg/onit/cluster.go
@@ -475,7 +475,7 @@ func (c *ClusterController) RemoveSimulator(name string) console.ErrorStatus {
 	if err := c.teardownSimulator(name); err != nil {
 		c.status.Fail(err)
 	}
-	c.status.Start("Reconfiguring onos-config nodes")
+	c.status.Start("Reconfiguring topology")
 	if err := c.removeSimulatorFromConfig(name); err != nil {
 		return c.status.Fail(err)
 	}
@@ -493,7 +493,7 @@ func (c *ClusterController) RemoveNetwork(name string) console.ErrorStatus {
 	if err := c.teardownNetwork(name); err != nil {
 		c.status.Fail(err)
 	}
-	c.status.Start("Reconfiguring onos-config nodes")
+	c.status.Start("Reconfiguring topology")
 	if err := c.removeNetworkFromConfig(name, configMaps); err != nil {
 		return c.status.Fail(err)
 	}

--- a/pkg/onit/onos-cli.go
+++ b/pkg/onit/onos-cli.go
@@ -82,7 +82,6 @@ func (c *ClusterController) OpenShell(resourceID string) error {
 
 // setupOnosCli sets up the onos-cli deployment
 func (c *ClusterController) setupOnosCli() error {
-
 	if err := c.createCliDeployment(); err != nil {
 		return err
 	}

--- a/pkg/onit/onos-config.go
+++ b/pkg/onit/onos-config.go
@@ -15,17 +15,14 @@
 package onit
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 
-	"gopkg.in/yaml.v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,125 +103,6 @@ func (c *ClusterController) createOnosConfigConfigMap() error {
 	}
 	_, err = c.kubeclient.CoreV1().ConfigMaps(c.clusterID).Create(cm)
 	return err
-}
-
-// addSimulatorToConfig adds a simulator to the onos-config configuration
-func (c *ClusterController) addSimulatorToConfig(name string) error {
-	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
-	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, pod := range pods.Items {
-		if err = c.addSimulatorToPod(name, pod); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// addNetworkToConfig adds a network to the onos-config configuration
-func (c *ClusterController) addNetworkToConfig(name string, config *NetworkConfig) error {
-	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
-	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, pod := range pods.Items {
-		var port = 50001
-		for i := 0; i < config.NumDevices; i++ {
-			var buf bytes.Buffer
-			buf.WriteString(name)
-			buf.WriteString("-s")
-			buf.WriteString(strconv.Itoa(i))
-			deviceName := buf.String()
-			if err = c.addNetworkToPod(deviceName, port, pod); err != nil {
-				return err
-			}
-			port = port + 1
-		}
-	}
-	return nil
-}
-
-// addSimulatorToPod adds the given simulator to the given pod's configuration
-func (c *ClusterController) addSimulatorToPod(name string, pod corev1.Pod) error {
-	command := fmt.Sprintf("onos devices add \"id: '%s', address: '%s:10161' version: '1.0.0' devicetype: 'Devicesim'\" --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/client1.key --certPath /etc/onos-config/certs/client1.crt", name, name)
-	return c.execute(pod, []string{"/bin/bash", "-c", command})
-}
-
-// addNetworkToPod adds the given network to the given pod's configuration
-func (c *ClusterController) addNetworkToPod(name string, port int, pod corev1.Pod) error {
-	command := fmt.Sprintf("onos devices add \"id: '%s', address: '%s:%s' version: '1.0.0' devicetype: 'Stratum'\" --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/client1.key --certPath /etc/onos-config/certs/client1.crt", name, name, strconv.Itoa(port))
-	return c.execute(pod, []string{"/bin/bash", "-c", command})
-}
-
-// removeSimulatorFromConfig removes a simulator from the onos-config configuration
-func (c *ClusterController) removeSimulatorFromConfig(name string) error {
-	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
-	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
-	})
-	if err != nil {
-		return err
-	}
-
-	for _, pod := range pods.Items {
-		if err = c.removeSimulatorFromPod(name, pod); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// removeNetworkFromConfig removes a network from the onos-config configuration
-func (c *ClusterController) removeNetworkFromConfig(name string, configMap *corev1.ConfigMapList) error {
-	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "config"}}
-	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
-		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
-	})
-	if err != nil {
-		return err
-	}
-	dataMap := configMap.Items[0].BinaryData["config"]
-	m := make(map[string]interface{})
-	err = yaml.Unmarshal(dataMap, &m)
-	if err != nil {
-		return err
-	}
-	numDevices := m["numdevices"].(int)
-
-	for _, pod := range pods.Items {
-		for i := 0; i < numDevices; i++ {
-			var buf bytes.Buffer
-			buf.WriteString(name)
-			buf.WriteString("-s")
-			buf.WriteString(strconv.Itoa(i))
-			deviceName := buf.String()
-			if err = c.removeNetworkFromPod(deviceName, pod); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// removeSimulatorFromPod removes the given simulator from the given pod
-func (c *ClusterController) removeSimulatorFromPod(name string, pod corev1.Pod) error {
-	command := fmt.Sprintf("onos devices remove %s --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/client1.key --certPath /etc/onos-config/certs/client1.crt", name)
-	return c.execute(pod, []string{"/bin/bash", "-c", command})
-}
-
-// removeNetworkFromPod removes the given network from the given pod
-func (c *ClusterController) removeNetworkFromPod(name string, pod corev1.Pod) error {
-	command := fmt.Sprintf("onos devices remove %s --address 127.0.0.1:5150 --keyPath /etc/onos-config/certs/client1.key --certPath /etc/onos-config/certs/client1.crt", name)
-	return c.execute(pod, []string{"/bin/bash", "-c", command})
 }
 
 // createOnosConfigDeployment creates an onos-config Deployment

--- a/pkg/onit/onos-topo.go
+++ b/pkg/onit/onos-topo.go
@@ -420,7 +420,7 @@ func (c *ClusterController) awaitOnosTopoProxyDeploymentReady() error {
 
 // addSimulatorToTopo adds a simulator to onos-topo
 func (c *ClusterController) addSimulatorToTopo(name string) error {
-	return c.addDevice("devicesim", name, 11161)
+	return c.addDevice("Devicesim", name, 11161)
 }
 
 // addNetworkToTopo adds a network to onos-topo
@@ -432,7 +432,7 @@ func (c *ClusterController) addNetworkToTopo(name string, config *NetworkConfig)
 		buf.WriteString("-s")
 		buf.WriteString(strconv.Itoa(i))
 		deviceName := buf.String()
-		if err := c.addDevice("stratum", deviceName, port); err != nil {
+		if err := c.addDevice("Stratum", deviceName, port); err != nil {
 			return err
 		}
 		port = port + 1

--- a/pkg/onit/simulator.go
+++ b/pkg/onit/simulator.go
@@ -100,11 +100,11 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 					ImagePullPolicy: c.config.PullPolicy,
 					Env: []corev1.EnvVar{
 						{
-							Name: "GNMI_PORT",
+							Name:  "GNMI_PORT",
 							Value: "10161",
 						},
 						{
-							Name: "GNMI_INSECURE_PORT",
+							Name:  "GNMI_INSECURE_PORT",
 							Value: "11161",
 						},
 					},

--- a/pkg/onit/simulator.go
+++ b/pkg/onit/simulator.go
@@ -98,16 +98,30 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 					Name:            "onos-device-simulator",
 					Image:           c.imageName("onosproject/device-simulator", c.config.ImageTags["simulator"]),
 					ImagePullPolicy: c.config.PullPolicy,
+					Env: []corev1.EnvVar{
+						{
+							Name: "GNMI_PORT",
+							Value: "10161",
+						},
+						{
+							Name: "GNMI_INSECURE_PORT",
+							Value: "11161",
+						},
+					},
 					Ports: []corev1.ContainerPort{
 						{
-							Name:          "gnmi",
+							Name:          "secure",
 							ContainerPort: 10161,
+						},
+						{
+							Name:          "insecure",
+							ContainerPort: 11161,
 						},
 					},
 					ReadinessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							TCPSocket: &corev1.TCPSocketAction{
-								Port: intstr.FromInt(10161),
+								Port: intstr.FromInt(11161),
 							},
 						},
 						InitialDelaySeconds: 5,
@@ -116,7 +130,7 @@ func (c *ClusterController) createSimulatorPod(name string) error {
 					LivenessProbe: &corev1.Probe{
 						Handler: corev1.Handler{
 							TCPSocket: &corev1.TCPSocketAction{
-								Port: intstr.FromInt(10161),
+								Port: intstr.FromInt(11161),
 							},
 						},
 						InitialDelaySeconds: 15,
@@ -164,8 +178,12 @@ func (c *ClusterController) createSimulatorService(name string) error {
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name: "gnmi",
+					Name: "secure",
 					Port: 10161,
+				},
+				{
+					Name: "insecure",
+					Port: 11161,
 				},
 			},
 		},


### PR DESCRIPTION
Use the `onos topo` command via the topo service to add devices to onit clusters.

This PR is a work in progress and requires some additional changes to allow secrets to be propagated to the config service.