### PR TITLE
use gui image tag for its deployment

### DIFF
--- a/pkg/onit/cli/create.go
+++ b/pkg/onit/cli/create.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/onosproject/onos-test/pkg/onit"
@@ -57,6 +58,9 @@ func initImageTags(imageTags map[string]string) {
 	}
 	if imageTags["topo"] == "" {
 		imageTags["topo"] = string(onit.Debug)
+	}
+	if imageTags["gui"] == "" {
+		imageTags["gui"] = string(onit.Latest)
 	}
 	if imageTags["atomix"] == "" {
 		imageTags["atomix"] = string(onit.Latest)
@@ -154,6 +158,7 @@ func getCreateClusterCommand() *cobra.Command {
 	imageTags["test"] = string(onit.Latest)
 	imageTags["atomix"] = string(onit.Latest)
 	imageTags["raft"] = string(onit.Latest)
+	imageTags["gui"] = string(onit.Latest)
 
 	cmd.Flags().StringP("config", "c", "default", "test cluster configuration")
 	cmd.Flags().String("docker-registry", "", "an optional host:port for a private Docker registry")

--- a/pkg/onit/gui.go
+++ b/pkg/onit/gui.go
@@ -63,7 +63,7 @@ func (c *ClusterController) createGUIDeployment() error {
 					Containers: []corev1.Container{
 						{
 							Name:            "onos-gui",
-							Image:           c.imageName("onosproject/onos-gui", "latest"),
+							Image:           c.imageName("onosproject/onos-gui", c.config.ImageTags["gui"]),
 							ImagePullPolicy: c.config.PullPolicy,
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
This PR changes the argument of `c.imageName` function for deployment of onos-gui to read it from image tags.