### PR TITLE
Add ssh capability to onit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8
 	google.golang.org/grpc v1.22.1
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
 	k8s.io/api v0.0.0-20190620073856-dcce3486da33

--- a/pkg/onit/cli/cli.go
+++ b/pkg/onit/cli/cli.go
@@ -60,7 +60,7 @@ func Subset(first, second []string) bool {
 func GetOnitCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                    "onit",
-		Short:                  "Run onos-config integration tests on Kubernetes",
+		Short:                  "Run onos integration tests on Kubernetes",
 		BashCompletionFunction: bashCompletion,
 	}
 	cmd.AddCommand(getCreateCommand())
@@ -73,6 +73,8 @@ func GetOnitCommand(registry *runner.TestRegistry) *cobra.Command {
 	cmd.AddCommand(getDebugCommand())
 	cmd.AddCommand(getFetchCommand())
 	cmd.AddCommand(getCompletionCommand())
+	cmd.AddCommand(getSSHCommand())
+	cmd.AddCommand(getOnosCliCommand())
 
 	return cmd
 }

--- a/pkg/onit/cli/completion.go
+++ b/pkg/onit/cli/completion.go
@@ -110,7 +110,7 @@ __onit_custom_func() {
             return
             ;;	
 			
-        onit_get_logs | onit_fetch_logs | onit_debug)
+        onit_get_logs | onit_fetch_logs | onit_debug | onit_ssh)
             if [[ ${#nouns[@]} -eq 0 ]]; then
                 __onit_get_nodes
             fi

--- a/pkg/onit/cli/get.go
+++ b/pkg/onit/cli/get.go
@@ -457,6 +457,14 @@ func getGetNodesCommand() *cobra.Command {
 					printNodes(nodes, !noHeaders)
 				}
 
+			} else if strings.Compare(nodeType, string(onit.OnosCli)) == 0 {
+				nodes, err := cluster.GetOnosCliNodes()
+				if err != nil {
+					exitError(err)
+				} else {
+					noHeaders, _ := cmd.Flags().GetBool("no-headers")
+					printNodes(nodes, !noHeaders)
+				}
 			}
 		},
 	}

--- a/pkg/onit/cli/ssh.go
+++ b/pkg/onit/cli/ssh.go
@@ -1,0 +1,110 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/onosproject/onos-test/pkg/onit"
+	"github.com/spf13/cobra"
+)
+
+var (
+	sshExample = `
+		# open a ssh connection to a node in the cluster to execute remote commands
+		onit ssh <name of a node>`
+)
+
+func getOnosCliCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "onos-cli",
+		Short:   "Open onos-cli shell for executing commands",
+		Example: sshExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get the onit controller
+			controller, err := onit.NewController()
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster ID
+			clusterID, err := cmd.Flags().GetString("cluster")
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster controller
+			cluster, err := controller.GetCluster(clusterID)
+			if err != nil {
+				exitError(err)
+			}
+
+			onosCliNodes, err := cluster.GetOnosCliNodes()
+			if err != nil {
+				exitError(err)
+			}
+
+			err = cluster.OpenShell(onosCliNodes[0].ID)
+			if err != nil {
+				exitError(err)
+			}
+
+		},
+	}
+	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to run onos-cli")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+
+}
+
+// getSshCommand returns a cobra "ssh" command to open a ssh session to a node for executing remote commands
+func getSSHCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "ssh <resource>",
+		Short:   "Open a ssh session to a node for executing remote commands",
+		Example: sshExample,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			// Get the onit controller
+			controller, err := onit.NewController()
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster ID
+			clusterID, err := cmd.Flags().GetString("cluster")
+			if err != nil {
+				exitError(err)
+			}
+
+			// Get the cluster controller
+			cluster, err := controller.GetCluster(clusterID)
+			if err != nil {
+				exitError(err)
+			}
+
+			err = cluster.OpenShell(args[0])
+			if err != nil {
+				exitError(err)
+			}
+
+		},
+	}
+	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster for which to ssh into nodes")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+}

--- a/pkg/onit/common.go
+++ b/pkg/onit/common.go
@@ -50,6 +50,9 @@ const (
 	// OnosApp type of node is app
 	OnosApp NodeType = "app"
 
+	//OnosCli type of node is cli
+	OnosCli NodeType = "cli"
+
 	// OnosAll type of node is all
 	OnosAll NodeType = "all"
 )
@@ -78,7 +81,9 @@ func (c *ClusterController) GetNodes() ([]NodeInfo, error) {
 
 	onosTopoNodes, _ := c.GetOnosTopoNodes()
 	onosConfigNodes, _ := c.GetOnosConfigNodes()
+	onosCliNodes, _ := c.GetOnosCliNodes()
 	nodes := append(onosTopoNodes, onosConfigNodes...)
+	nodes = append(nodes, onosCliNodes...)
 
 	return nodes, nil
 }

--- a/pkg/onit/onos-cli.go
+++ b/pkg/onit/onos-cli.go
@@ -15,12 +15,70 @@
 package onit
 
 import (
+	"os"
 	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+
+	"golang.org/x/crypto/ssh/terminal"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// OpenShell opens a shell session to the given resource
+func (c *ClusterController) OpenShell(resourceID string) error {
+	pod, err := c.kubeclient.CoreV1().Pods(c.clusterID).Get(resourceID, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	container := pod.Spec.Containers[0]
+	req := c.kubeclient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(pod.Name).
+		Namespace(pod.Namespace).
+		SubResource("exec").
+		Param("container", container.Name)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container.Name,
+		Command:   []string{"/bin/sh"},
+		Stdout:    true,
+		Stdin:     true,
+		TTY:       true,
+	}, scheme.ParameterCodec)
+
+	config, err := getRestConfig()
+	if err != nil {
+		return err
+	}
+
+	exec, err := remotecommand.NewSPDYExecutor(config, "POST", req.URL())
+	if err != nil {
+		return err
+	}
+	oldState, err := terminal.MakeRaw(0)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		err := terminal.Restore(0, oldState)
+		if err != nil {
+			panic(err)
+		}
+
+	}()
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  os.Stdin,
+		Stdout: os.Stdout,
+		Tty:    true,
+	})
+	return err
+}
 
 // setupOnosCli sets up the onos-cli deployment
 func (c *ClusterController) setupOnosCli() error {
@@ -89,4 +147,33 @@ func (c *ClusterController) awaitCliDeploymentReady() error {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
+}
+
+// GetOnosTopoNodes returns a list of all onos-topo nodes running in the cluster
+func (c *ClusterController) GetOnosCliNodes() ([]NodeInfo, error) {
+	topoLabelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"app": "onos", "type": "cli"}}
+
+	pods, err := c.kubeclient.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: labels.Set(topoLabelSelector.MatchLabels).String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	onosCliNodes := make([]NodeInfo, len(pods.Items))
+	for i, pod := range pods.Items {
+		var status NodeStatus
+		if pod.Status.Phase == corev1.PodRunning {
+			status = NodeRunning
+		} else if pod.Status.Phase == corev1.PodFailed {
+			status = NodeFailed
+		}
+		onosCliNodes[i] = NodeInfo{
+			ID:     pod.Name,
+			Status: status,
+			Type:   OnosCli,
+		}
+	}
+
+	return onosCliNodes, nil
 }


### PR DESCRIPTION
To address issue #8. 
In this PR we add two new commands:
1. `onit ssh <name of a pod>` : this command can be used to ssh into any of the onos subsystems such as onos-config, onos-cli, onos-topo, etc
2. `onit onos-cli:` To make the life easier for developers, we also have a command for executing onos-cli commands without using kubectl exec command or  `onit ssh` command. 

