### PR TITLE
Use named image arguments for app deployment

### DIFF
--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -177,7 +177,7 @@ func getAddAppCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "app image-name [name]",
 		Short: "Add an app to the test cluster",
-		Args:  cobra.MaximumNArgs(2),
+		Args:  cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			var name string
 			if len(args) == 1 {

--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -15,7 +15,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/onosproject/onos-test/pkg/onit/k8s"
@@ -192,7 +191,7 @@ func getAddAppCommand() *cobra.Command {
 			// Get the application image name. The image is a required flag.
 			image, _ := cmd.Flags().GetString("image")
 			if image == "" {
-				exitError(errors.New("must specify an --image to deploy"))
+				exitHelp(cmd, "--image flag is required")
 			}
 
 			imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")

--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/onosproject/onos-test/pkg/onit/k8s"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -177,13 +178,29 @@ func getAddAppCommand() *cobra.Command {
 		Short: "Add an app to the test cluster",
 		Args:  cobra.MaximumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			// If an app name was not provided, generate one from a UUID.
+			var image string
 			var name string
-
-			if len(args) > 1 {
-				name = args[1]
+			if len(args) == 0 {
+				image, _ = cmd.Flags().GetString("image")
+				name, _ = cmd.Flags().GetString("name")
+			} else if len(args) == 1 {
+				image = args[0]
+				name, _ = cmd.Flags().GetString("name")
 			} else {
+				image = args[0]
+				name = args[1]
+			}
+
+			// If the name is not set, assign a generic UUID based name.
+			if name == "" {
 				name = fmt.Sprintf("app-%d", newUUIDInt())
+			}
+
+			imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
+			pullPolicy := corev1.PullPolicy(imagePullPolicy)
+
+			if pullPolicy != corev1.PullAlways && pullPolicy != corev1.PullIfNotPresent && pullPolicy != corev1.PullNever {
+				exitError(fmt.Errorf("invalid pull policy; must of one of %s, %s or %s", corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever))
 			}
 
 			// Get the onit controller
@@ -205,9 +222,9 @@ func getAddAppCommand() *cobra.Command {
 			}
 
 			// Create the app configuration
-			imageName := args[0]
 			config := &k8s.AppConfig{
-				Image: imageName,
+				Image:      image,
+				PullPolicy: pullPolicy,
 			}
 
 			// Add the app to the cluster
@@ -219,6 +236,9 @@ func getAddAppCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringP("name", "n", "", "the application name")
+	cmd.Flags().StringP("image", "i", "", "the image name")
+	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to which to add the app")
 	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
 		cobra.BashCompCustom: {"__onit_get_clusters"},

--- a/pkg/onit/cli/add.go
+++ b/pkg/onit/cli/add.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/onosproject/onos-test/pkg/onit/k8s"
@@ -178,22 +179,20 @@ func getAddAppCommand() *cobra.Command {
 		Short: "Add an app to the test cluster",
 		Args:  cobra.MaximumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			var image string
 			var name string
-			if len(args) == 0 {
-				image, _ = cmd.Flags().GetString("image")
-				name, _ = cmd.Flags().GetString("name")
-			} else if len(args) == 1 {
-				image = args[0]
-				name, _ = cmd.Flags().GetString("name")
-			} else {
-				image = args[0]
-				name = args[1]
+			if len(args) == 1 {
+				name = args[0]
 			}
 
 			// If the name is not set, assign a generic UUID based name.
 			if name == "" {
 				name = fmt.Sprintf("app-%d", newUUIDInt())
+			}
+
+			// Get the application image name. The image is a required flag.
+			image, _ := cmd.Flags().GetString("image")
+			if image == "" {
+				exitError(errors.New("must specify an --image to deploy"))
 			}
 
 			imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
@@ -236,7 +235,6 @@ func getAddAppCommand() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP("name", "n", "", "the application name")
 	cmd.Flags().StringP("image", "i", "", "the image name")
 	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
 	cmd.Flags().StringP("cluster", "c", getDefaultCluster(), "the cluster to which to add the app")

--- a/pkg/onit/cli/cli.go
+++ b/pkg/onit/cli/cli.go
@@ -110,3 +110,11 @@ func exitError(err error) {
 	fmt.Println(err)
 	os.Exit(1)
 }
+
+// exitHelp prints the given error message plus the command help
+func exitHelp(cmd *cobra.Command, message string) {
+	fmt.Println(message)
+	fmt.Println()
+	_ = cmd.Help()
+	os.Exit(1)
+}

--- a/pkg/onit/k8s/app.go
+++ b/pkg/onit/k8s/app.go
@@ -49,7 +49,7 @@ func (c *ClusterController) setupApp(name string, config *AppConfig) error {
 	if err := c.createAppService(name); err != nil {
 		return err
 	}
-	if err := c.createOnosAppDeployment(name, config.Image); err != nil {
+	if err := c.createOnosAppDeployment(name, config.Image, config.PullPolicy); err != nil {
 		return err
 	}
 	if err := c.awaitOnosAppDeploymentReady(name); err != nil {
@@ -72,7 +72,7 @@ func (c *ClusterController) createAppConfigMap(name string, config *AppConfig) e
 }
 
 // createOnosAppDeployment creates an app Deployment
-func (c *ClusterController) createOnosAppDeployment(name string, image string) error {
+func (c *ClusterController) createOnosAppDeployment(name string, image string, pullPolicy corev1.PullPolicy) error {
 	nodes := int32(1)
 	zero := int64(0)
 	dep := &appsv1.Deployment{
@@ -108,7 +108,7 @@ func (c *ClusterController) createOnosAppDeployment(name string, image string) e
 						{
 							Name:            name,
 							Image:           image,
-							ImagePullPolicy: corev1.PullIfNotPresent,
+							ImagePullPolicy: pullPolicy,
 							Env: []corev1.EnvVar{
 								{
 									Name:  "ATOMIX_CONTROLLER",

--- a/pkg/onit/k8s/config.go
+++ b/pkg/onit/k8s/config.go
@@ -72,7 +72,7 @@ type SimulatorConfig struct {
 
 // AppConfig provides the configuration for an app
 type AppConfig struct {
-	Image           string
+	Image      string
 	PullPolicy corev1.PullPolicy
 }
 

--- a/pkg/onit/k8s/config.go
+++ b/pkg/onit/k8s/config.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -37,7 +37,7 @@ type ClusterConfig struct {
 	Registry      string            `yaml:"registry" mapstructure:"registry"`
 	Preset        string            `yaml:"preset" mapstructure:"preset"`
 	ImageTags     map[string]string `yaml:"image-tags" mapstructure:"image-tags"`
-	PullPolicy    v1.PullPolicy     `yaml:"pull-policy" mapstructure:"pull-policy"`
+	PullPolicy    corev1.PullPolicy `yaml:"pull-policy" mapstructure:"pull-policy"`
 	ConfigNodes   int               `yaml:"configNodes" mapstructure:"topoNodes"`
 	TopoNodes     int               `yaml:"topoNodes" mapstructure:"topoNodes"`
 	Partitions    int               `yaml:"partitions" mapstructure:"partitions"`
@@ -72,7 +72,8 @@ type SimulatorConfig struct {
 
 // AppConfig provides the configuration for an app
 type AppConfig struct {
-	Image string
+	Image           string
+	PullPolicy corev1.PullPolicy
 }
 
 // NetworkConfig provides the configuration for a stratum network


### PR DESCRIPTION
This PR modifies the `onit add app` command to adhere to command design conventions. The use of multiple positional arguments can be confusing - image name first, or app name? - so this follows the same convention as other commands in allowing only a single optional argument - the app name - and requiring an `--image`/`-i` name.

```
onit add app onos-ztp --image onosproject/onos-ztp:latest
```