### PR TITLE
Configure Atomix CLI to connect to test controller

### DIFF
--- a/pkg/onit/k8s/onos-config.go
+++ b/pkg/onit/k8s/onos-config.go
@@ -183,7 +183,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 								},
 								{
 									Name:  "ATOMIX_APP",
-									Value: "test",
+									Value: "onos-config",
 								},
 								{
 									Name:  "ATOMIX_NAMESPACE",

--- a/pkg/onit/k8s/onos-topo.go
+++ b/pkg/onit/k8s/onos-topo.go
@@ -140,7 +140,7 @@ func (c *ClusterController) createOnosTopoDeployment() error {
 								},
 								{
 									Name:  "ATOMIX_APP",
-									Value: "test",
+									Value: "onos-topo",
 								},
 								{
 									Name:  "ATOMIX_NAMESPACE",


### PR DESCRIPTION
This PR configures the `atomix` CLI deployed as part of the `onos-cli` deployment to connect to the correct controller in the test namespace etc. The Atomix CLI can then be used immediately once connected to the onos-cli container.

It also updates the environment variables set for the `onos-topo` and `onos-config` deployments to ensure their primitives are not visible to one another.