### PR TITLE
Update device tests to avoid new error checking

### DIFF
--- a/test/topo/cli.go
+++ b/test/topo/cli.go
@@ -29,9 +29,9 @@ func init() {
 
 const (
 	devicesHeader = "ID ADDRESS VERSION"
-	addedFoo      = "Added device foo"
-	removedFoo    = "Removed device foo"
-	devicesFoo    = "foo foo:1234 1.0.0"
+	addedTest     = "Added device test"
+	removedTest   = "Removed device test"
+	devicesTest   = "test test:1234 1.0.0"
 )
 
 // TestTopoDeviceCLI tests the topo service's device CLI commands
@@ -44,21 +44,21 @@ func TestTopoDeviceCLI(t *testing.T) {
 	assert.Len(t, output, 1)
 	assert.Equal(t, devicesHeader, stripSpaces(output[0]))
 
-	output, code = env.ExecuteCLI("onos topo add device foo --type Devicesim --address foo:1234 --version 1.0.0")
+	output, code = env.ExecuteCLI("onos topo add device test --type Devicesim --address test:1234 --version 1.0.0")
 	assert.Equal(t, 0, code)
 	assert.Len(t, output, 1)
-	assert.Equal(t, addedFoo, output[0])
+	assert.Equal(t, addedTest, output[0])
 
 	output, code = env.ExecuteCLI("onos topo get devices")
 	assert.Equal(t, 0, code)
 	assert.Len(t, output, 2)
 	assert.Equal(t, devicesHeader, stripSpaces(output[0]))
-	assert.Equal(t, devicesFoo, stripSpaces(output[1]))
+	assert.Equal(t, devicesTest, stripSpaces(output[1]))
 
-	output, code = env.ExecuteCLI("onos topo remove device foo")
+	output, code = env.ExecuteCLI("onos topo remove device test")
 	assert.Equal(t, 0, code)
 	assert.Len(t, output, 1)
-	assert.Equal(t, removedFoo, output[0])
+	assert.Equal(t, removedTest, output[0])
 
 	output, code = env.ExecuteCLI("onos topo get devices")
 	assert.Equal(t, 0, code)

--- a/test/topo/device.go
+++ b/test/topo/device.go
@@ -60,35 +60,37 @@ func TestDeviceService(t *testing.T) {
 
 		for {
 			response, err := list.Recv()
-			if err == io.EOF {
+			if err != nil {
 				break
 			}
-			assert.NoError(t, err)
 			events <- response
 		}
 	}()
 
 	addResponse, err := client.Add(context.Background(), &device.AddRequest{
 		Device: &device.Device{
-			ID:      "foo",
-			Address: "device-foo:5000",
+			ID:      "test1",
+			Type:    "Stratum",
+			Address: "device-test1:5000",
+			Target:  "device-test1",
+			Version: "1.0.0",
 		},
 	})
 	assert.NoError(t, err)
-	assert.Equal(t, device.ID("foo"), addResponse.Device.ID)
+	assert.Equal(t, device.ID("test1"), addResponse.Device.ID)
 	assert.NotEqual(t, device.Revision(0), addResponse.Device.Revision)
 
 	getResponse, err := client.Get(context.Background(), &device.GetRequest{
-		ID: "foo",
+		ID: "test1",
 	})
 	assert.NoError(t, err)
 
-	assert.Equal(t, device.ID("foo"), getResponse.Device.ID)
+	assert.Equal(t, device.ID("test1"), getResponse.Device.ID)
 	assert.Equal(t, addResponse.Device.Revision, getResponse.Device.Revision)
 
 	eventResponse := <-events
 	assert.Equal(t, device.ListResponse_ADDED, eventResponse.Type)
-	assert.Equal(t, device.ID("foo"), eventResponse.Device.ID)
+	assert.Equal(t, device.ID("test1"), eventResponse.Device.ID)
 	assert.Equal(t, addResponse.Device.Revision, eventResponse.Device.Revision)
 
 	list, err = client.List(context.Background(), &device.ListRequest{})
@@ -100,7 +102,7 @@ func TestDeviceService(t *testing.T) {
 		}
 		assert.NoError(t, err)
 		assert.Equal(t, device.ListResponse_NONE, response.Type)
-		assert.Equal(t, device.ID("foo"), response.Device.ID)
+		assert.Equal(t, device.ID("test1"), response.Device.ID)
 		assert.Equal(t, addResponse.Device.Revision, response.Device.Revision)
 		count++
 	}
@@ -114,6 +116,6 @@ func TestDeviceService(t *testing.T) {
 
 	eventResponse = <-events
 	assert.Equal(t, device.ListResponse_REMOVED, eventResponse.Type)
-	assert.Equal(t, device.ID("foo"), eventResponse.Device.ID)
+	assert.Equal(t, device.ID("test1"), eventResponse.Device.ID)
 	assert.Equal(t, addResponse.Device.Revision, eventResponse.Device.Revision)
 }


### PR DESCRIPTION
Fix bugs in device service/CLI tests. Since adding validation to the device service these tests are now failing. Of course, we need to add tests that include testing the validation aspects, but that will be left for another PR. Just wanted to get this into a passing state again.

I think @ray-milkey needs to clean up the CLI test to use whatever strategy he deems to be an improvement over my hacks.