### PR TITLE
Change Raft protocol configuration import to use atomix-api dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,19 +3,33 @@ module github.com/onosproject/onos-test
 go 1.12
 
 require (
+	github.com/atomix/atomix-api v0.0.0-20190826211343-dd8f4db3bf77
 	github.com/atomix/atomix-go-client v0.0.0-20190830184106-6ca178a89ccc
 	github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0
+	github.com/go-logfmt/logfmt v0.4.0 // indirect
+	github.com/go-playground/overalls v0.0.0-20180201144345-22ec1a223b7c // indirect
+	github.com/gofrs/flock v0.7.1 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
+	github.com/googleapis/gnostic v0.3.0 // indirect
+	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mattn/go-colorable v0.1.2 // indirect
+	github.com/mattn/goveralls v0.0.2 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/onosproject/onos-config v0.0.0-20190731170328-b4ee3a917c9f
+	github.com/onosproject/onos-config v0.0.0-20190829172900-8d24cb86fe8a
 	github.com/onosproject/onos-topo v0.0.0-20190830202023-54c5f0e99fb9
 	github.com/openconfig/gnmi v0.0.0-20180912164834-33a1865c3029
+	github.com/pelletier/go-toml v1.4.0 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
+	github.com/yookoala/realpath v1.0.0 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	google.golang.org/grpc v1.22.1
 	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68 h1:PC
 github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68/go.mod h1:vdmRfGKhgD28STeLKeKoq3tMZOyTR0l3WSG9QCrZWs0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -196,6 +198,8 @@ github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn
 github.com/onosproject/onos-config v0.0.0-20190715180819-079d3a8dc433/go.mod h1:1G4gt12sBESqda8mrmAmOjqfV7PT0CLle9VVm8Qtfp8=
 github.com/onosproject/onos-config v0.0.0-20190731170328-b4ee3a917c9f h1:8tOMe8Do6JBjSUvTtlvIGKwrmrDc+Fd1TypWPXlQi2I=
 github.com/onosproject/onos-config v0.0.0-20190731170328-b4ee3a917c9f/go.mod h1:1G4gt12sBESqda8mrmAmOjqfV7PT0CLle9VVm8Qtfp8=
+github.com/onosproject/onos-config v0.0.0-20190829172900-8d24cb86fe8a h1:365+D6WGfoWRVSNxicRZZxiBRDzG1qRqkX0CyNhO6vc=
+github.com/onosproject/onos-config v0.0.0-20190829172900-8d24cb86fe8a/go.mod h1:JKVnd7F928dHJ2bzKxd4wAL4aBVTh7Q20jCyrjv6Mo0=
 github.com/onosproject/onos-control v0.0.0-20190715190020-706a2ee0d37b/go.mod h1:pHxuBLlYpyZbiaBDKFkO+O9RixBd/qMPR8t5mizwbQY=
 github.com/onosproject/onos-topo v0.0.0-20190807224236-53dad829743b h1:tOZDE6vOBlE8stBksUvPJr9Yrj1kQlIbHMkWSI26G+8=
 github.com/onosproject/onos-topo v0.0.0-20190807224236-53dad829743b/go.mod h1:S39GNVp4OOuS4Y+u1NKmZ1AG0Y+cZ2arEOyYpN97XiI=

--- a/pkg/onit/k8s/partitions.go
+++ b/pkg/onit/k8s/partitions.go
@@ -19,8 +19,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/atomix/atomix-api/proto/atomix/protocols/raft"
 	"github.com/atomix/atomix-k8s-controller/pkg/apis/k8s/v1alpha1"
-	raft "github.com/atomix/atomix-k8s-controller/proto/atomix/protocols/raft"
 	"github.com/ghodss/yaml"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/env/env.go
+++ b/test/env/env.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 	atomix "github.com/atomix/atomix-go-client/pkg/client"
-	"github.com/onosproject/onos-config/pkg/northbound/proto"
+	"github.com/onosproject/onos-config/pkg/northbound/admin"
 	"github.com/openconfig/gnmi/client"
 	gnmi "github.com/openconfig/gnmi/client/gnmi"
 	"google.golang.org/grpc"
@@ -188,7 +188,7 @@ func GetConfigConn() (*grpc.ClientConn, error) {
 }
 
 // GetAdminClient returns a client that can be used for the admin APIs
-func GetAdminClient() (*grpc.ClientConn, proto.ConfigAdminServiceClient) {
+func GetAdminClient() (*grpc.ClientConn, admin.ConfigAdminServiceClient) {
 	opts, err := handleCertArgs()
 	if err != nil {
 		fmt.Printf("Error loading cert %s", err)
@@ -197,7 +197,7 @@ func GetAdminClient() (*grpc.ClientConn, proto.ConfigAdminServiceClient) {
 	if err != nil {
 		panic(err)
 	}
-	return conn, proto.NewConfigAdminServiceClient(conn)
+	return conn, admin.NewConfigAdminServiceClient(conn)
 }
 
 // NewAtomixClient returns an Atomix client from the environment

--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -20,7 +20,7 @@ import (
 	"github.com/onosproject/onos-test/test"
 	"testing"
 
-	admin "github.com/onosproject/onos-config/pkg/northbound/proto"
+	"github.com/onosproject/onos-config/pkg/northbound/admin"
 	"github.com/onosproject/onos-test/test/env"
 	"github.com/openconfig/gnmi/client"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
Fixes ```build github.com/onosproject/onos-test/cmd/onit: cannot load github.com/atomix/atomix-k8s-controller/proto/atomix/protocols/raft: cannot find module providing package github.com/atomix/atomix-k8s-controller/proto/atomix/protocols/raft```