### PR TITLE
Run config debug image in privileged mode

### DIFF
--- a/pkg/onit/k8s/onos-config.go
+++ b/pkg/onit/k8s/onos-config.go
@@ -146,6 +146,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 
 	}
 
+	privileged := c.config.ImageTags["config"] == "debug"
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "onos-config",
@@ -249,6 +250,7 @@ func (c *ClusterController) createOnosConfigDeployment() error {
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
+								Privileged: &privileged,
 								Capabilities: &corev1.Capabilities{
 									Add: []corev1.Capability{
 										"SYS_PTRACE",


### PR DESCRIPTION
In order to switch to Ubuntu in debug images (https://github.com/onosproject/onos-config/pull/673) debug images have to be deployed in privileged mode, otherwise:

```
could not launch process: fork/exec /usr/local/bin/onos-config: operation not permitted
```