### PR TITLE
Publish docker image for onos-test-runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,3 +55,8 @@ jobs:
       if: type != pull_request
       script:
           - sh build/bin/trigger-docs-travis $TRAVIS_ACCESS_TOKEN
+    - stage: push images
+      if: type != pull_request
+      script:
+          - sh build/bin/trigger-docs-travis $TRAVIS_ACCESS_TOKEN
+          - bash ./build/bin/push-images

--- a/build/bin/push-images
+++ b/build/bin/push-images
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+make images
+docker push onosproject/onos-test-runner:latest
+


### PR DESCRIPTION
This PR allows Travis CI to push new docker images for onos-test-runner on merge commits.