### PR TITLE
Import onos-test-runner into k3d cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ kind: images
 	@if [ "`kind get clusters`" = '' ]; then echo "no kind cluster found" && exit 1; fi
 	kind load docker-image onosproject/onos-test-runner:${ONOS_TEST_VERSION}
 
+k3d: # @HELP build Docker images and add them to the currently configured k3d cluster
+k3d: images
+	@if [ "`k3d list`" = '' ]; then echo "no k3d cluster found" && exit 1; fi
+	k3d import-images onosproject/onos-test-runner:${ONOS_TEST_VERSION}
 
 all: build images
 


### PR DESCRIPTION
I think k3d is a good tool to consider for a local cluster since it has all of the features of minikube, kind, mikrok8s + it supports ingress.  In addition, when you restart your computer, you can start the cluster without any problems and all of your deployments will get restarted as well.  In addition, it is a little bit faster than kind cluster. For now we can support it here in onos-test  and if we find it useful and a better option when compared with kind, we will add it into other subsystems as well. 