### PR TITLE
Update Atomix client to avoid retries on finite streams

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/onosproject/onos-test
 go 1.12
 
 require (
-	github.com/atomix/atomix-api v0.0.0-20191002225141-1ee9c98c7dfd
-	github.com/atomix/atomix-go-client v0.0.0-20191003001725-858dcf9a0ea0
+	github.com/atomix/atomix-api v0.0.0-20191005223910-aa620357faa0
+	github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310
 	github.com/atomix/atomix-k8s-controller v0.0.0-20190905035228-0c2f92a4bc0e
 	github.com/fatih/color v1.7.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/atomix/atomix-api v0.0.0-20190826211343-dd8f4db3bf77 h1:+PUuY9wDRp+VA
 github.com/atomix/atomix-api v0.0.0-20190826211343-dd8f4db3bf77/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
 github.com/atomix/atomix-api v0.0.0-20191002225141-1ee9c98c7dfd h1:D1Gsxu6L0UyPKcXJM/WUrdDYFyXrjlUP+nj6xhVp9N8=
 github.com/atomix/atomix-api v0.0.0-20191002225141-1ee9c98c7dfd/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
+github.com/atomix/atomix-api v0.0.0-20191005223910-aa620357faa0 h1:XHJB3g6Xkxj0GAyKNC5xOfqrJeGqFLFfVGqRaCeIxFM=
+github.com/atomix/atomix-api v0.0.0-20191005223910-aa620357faa0/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
 github.com/atomix/atomix-go-client v0.0.0-20190807011524-58b4352273d7 h1:XE+KsvclmfZjbqYDhBqeK8wHDDHYB/FiwGeLcBurYoM=
 github.com/atomix/atomix-go-client v0.0.0-20190807011524-58b4352273d7/go.mod h1:P/m0xcEzXviZLULk78gYlJr0mHjXCZAcem3kOkvwzhA=
 github.com/atomix/atomix-go-client v0.0.0-20190814013624-2b7049842ee1 h1:SW6b1TIATnNmsKrnGaoweY+uLezgUEKT61z3IGLKOts=
@@ -34,6 +36,8 @@ github.com/atomix/atomix-go-client v0.0.0-20190927194441-c6eb7ea90412/go.mod h1:
 github.com/atomix/atomix-go-client v0.0.0-20191002230120-837d618e27c5/go.mod h1:MoPkrAL33saKe2GbTi+NJgLzW7ejCwrrLDrYIwGYNcE=
 github.com/atomix/atomix-go-client v0.0.0-20191003001725-858dcf9a0ea0 h1:6y8Pwwd2Rk34E6wuXBf1+Twzs3rkY91Alu2Vg6w2boo=
 github.com/atomix/atomix-go-client v0.0.0-20191003001725-858dcf9a0ea0/go.mod h1:a/bqs5eosD+gOEGOWNScuf132W/WfCzshGe+afOoCaw=
+github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310 h1:rC8EI8qd8ab8vXtJhx8WxwMdYfRf7KhrhwnAEemwBQQ=
+github.com/atomix/atomix-go-client v0.0.0-20191007173732-5328130c1310/go.mod h1:OJHBatYnC3NkjfQl59ecAM+3UjJRN1KmjmBd5E6O4bg=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a h1:O/17kCIR6b+QeSkNpP12g/xTiDg976KSIS/8SSJ6Z/8=
@@ -41,6 +45,9 @@ github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a/go.mod h1:l
 github.com/atomix/atomix-go-local v0.0.0-20190917062229-6dbcfea7cd2f/go.mod h1:wGsoqWNZmfM5YkWMETZh24U9b7yZ0W1V8hZ7kVbKBgg=
 github.com/atomix/atomix-go-local v0.0.0-20191002230335-39d2b157c446 h1:XjhOLpQkhsGuRuMGWInSatYRGFXR+oF+OCzXBL8OPo0=
 github.com/atomix/atomix-go-local v0.0.0-20191002230335-39d2b157c446/go.mod h1:liCwtlGHMXFwW5A1o3BlmEldqkxgYpk99sdOXQhEVhM=
+github.com/atomix/atomix-go-local v0.0.0-20191005004851-a9403b577637/go.mod h1:syI/GoUBKhGASfFqx9sCqoSLCopSC4mEpzxCI7sLjDU=
+github.com/atomix/atomix-go-local v0.0.0-20191005233404-a691d226511f h1:yaILV01XYXzKuFUZsw5qE6g0YiqT5WldKw40kEMv7eQ=
+github.com/atomix/atomix-go-local v0.0.0-20191005233404-a691d226511f/go.mod h1:6uWLpSvA1yC0uJvG46qQ93jhGsYxjUJA+c2Mw6rts4c=
 github.com/atomix/atomix-go-node v0.0.0-20190827191929-2d3dc9c550d9/go.mod h1:PL1T5R78itch1QC1CN4JmbRL/2XQlg4R95R14822C6Q=
 github.com/atomix/atomix-go-node v0.0.0-20190828183436-fc30340cd8db/go.mod h1:dyh8Bb50qKfMlpqDE6X+dQ1tZ399WKEABa3ntDYImnA=
 github.com/atomix/atomix-go-node v0.0.0-20190830183721-649263a17223/go.mod h1:KJxB/MAgndAbyCOqTV2hatw7lExiZZs7QCOr45IfC9U=
@@ -49,6 +56,9 @@ github.com/atomix/atomix-go-node v0.0.0-20190830183818-a5b5157566f6/go.mod h1:39
 github.com/atomix/atomix-go-node v0.0.0-20190917012211-d4866b018ab6/go.mod h1:fQ/oMxUHpVMugRSWfBhS2z1l8TXyXOoNlLdq43eVAOU=
 github.com/atomix/atomix-go-node v0.0.0-20191002230317-dabfbb700511 h1:njY6QOjKA661GARaHY6jgIjZlArTR0P1l0TJvWjQHjw=
 github.com/atomix/atomix-go-node v0.0.0-20191002230317-dabfbb700511/go.mod h1:qkkk2Kd2UvftwukgjqLNJtaXjYJl+WIvDCm+HjkjLKg=
+github.com/atomix/atomix-go-node v0.0.0-20191005004840-a11d88ec22cd/go.mod h1:m3BU2Yn1nJ/inhJS9I7Epqra4RfjIR2nkTheX8UGcs0=
+github.com/atomix/atomix-go-node v0.0.0-20191005232742-ebda59622853 h1:gKRVpzS3fKmQTRXFM21Y9cl+Jzz4oRv0ZJ5VLp3n2ps=
+github.com/atomix/atomix-go-node v0.0.0-20191005232742-ebda59622853/go.mod h1:eQpS42TVM24rJW+9lJRl1EJIi3YGPjTv1xsNYxuMrf0=
 github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68 h1:PCOXQ9q2rP/oYVNAFHR1LIqyD5JXQ19saZUKc4MkfR8=
 github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68/go.mod h1:vdmRfGKhgD28STeLKeKoq3tMZOyTR0l3WSG9QCrZWs0=
 github.com/atomix/atomix-k8s-controller v0.0.0-20190905035228-0c2f92a4bc0e h1:YJyjc60GiCyyWttQtVmLutmUJH41Wyqe/i5h7UdLwkc=


### PR DESCRIPTION
Fixes a bug in the Atomix client that retried finite streams e.g. device list