### PR TITLE
Extension integration

### DIFF
--- a/test/integration/gnmiutils.go
+++ b/test/integration/gnmiutils.go
@@ -35,7 +35,7 @@ type DevicePath struct {
 	pathDataValue string
 }
 
-func convertGetResults(response *gpb.GetResponse) ([]DevicePath, error) {
+func convertGetResults(response *gpb.GetResponse) ([]DevicePath, []*gnmi_ext.Extension, error) {
 	entryCount := len(response.Notification)
 	result := make([]DevicePath, entryCount)
 
@@ -58,7 +58,7 @@ func convertGetResults(response *gpb.GetResponse) ([]DevicePath, error) {
 		}
 	}
 
-	return result, nil
+	return result, response.Extension, nil
 }
 
 func extractSetTransactionID(response *gpb.SetResponse) string {
@@ -82,8 +82,7 @@ func GNMIGet(ctx context.Context, c client.Impl, paths []DevicePath) ([]DevicePa
 	if err != nil || response == nil {
 		return nil, nil, err
 	}
-	pathsResp, errResp := convertGetResults(response)
-	return pathsResp, getTZRequest.Extension, errResp
+	return convertGetResults(response)
 }
 
 // GNMISet generates a SET request on the given client for a path on a device
@@ -117,8 +116,8 @@ func GNMIDelete(ctx context.Context, c client.Impl, devicePaths []DevicePath) ([
 		return nil, err
 	}
 
-	_, err := c.(*gclient.Client).Set(ctx, setTZRequest)
-	return setTZRequest.Extension, err
+	response, err := c.(*gclient.Client).Set(ctx, setTZRequest)
+	return response.Extension, err
 }
 
 // MakeContext returns a new context for use in GNMI requests

--- a/test/integration/modelstest.go
+++ b/test/integration/modelstest.go
@@ -74,7 +74,7 @@ func TestModels(t *testing.T) {
 				setResult := makeDevicePath(device, path)
 				setResult[0].pathDataValue = value
 				setResult[0].pathDataType = valueType
-				_, errorSet := GNMISet(MakeContext(), gnmiClient, setResult)
+				_, _, errorSet := GNMISet(MakeContext(), gnmiClient, setResult)
 				assert.NotNil(t, errorSet, "Set operation for %s does not generate an error", description)
 				assert.Contains(t, errorSet.Error(),
 					expectedError,

--- a/test/integration/singlepathtest.go
+++ b/test/integration/singlepathtest.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"github.com/onosproject/onos-test/pkg/runner"
 	"github.com/onosproject/onos-test/test"
+	"strconv"
 	"testing"
 
 	"github.com/onosproject/onos-test/test/env"
@@ -51,24 +52,26 @@ func TestSinglePath(t *testing.T) {
 	setPath[0].pathDataType = StringVal
 	_, extensions, errorSet := GNMISet(MakeContext(), c, setPath)
 	assert.NoError(t, errorSet)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 1, len(extensions))
+	extension := extensions[0].GetRegisteredExt()
+	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	// Check that the value was set correctly
 	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorAfter)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, tzValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
 
 	// Remove the path we added
 	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorDelete)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 
 	//  Make sure it got removed
 	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorAfterDelete)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "",
 		"incorrect value found for path /system/clock/config/timezone-name after delete")
 }

--- a/test/integration/singlepathtest.go
+++ b/test/integration/singlepathtest.go
@@ -49,22 +49,26 @@ func TestSinglePath(t *testing.T) {
 	setPath := makeDevicePath(device, tzPath)
 	setPath[0].pathDataValue = tzValue
 	setPath[0].pathDataType = StringVal
-	_, errorSet := GNMISet(MakeContext(), c, setPath)
+	_, extensions, errorSet := GNMISet(MakeContext(), c, setPath)
 	assert.NoError(t, errorSet)
+	assert.Equal(t, len(extensions), 0)
 
 	// Check that the value was set correctly
-	valueAfter, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, tzPath))
+	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorAfter)
+	assert.Equal(t, len(extensions), 0)
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, tzValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
 
 	// Remove the path we added
-	errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, tzPath))
+	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorDelete)
+	assert.Equal(t, len(extensions), 0)
 
 	//  Make sure it got removed
-	valueAfterDelete, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, tzPath))
+	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorAfterDelete)
+	assert.Equal(t, len(extensions), 0)
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "",
 		"incorrect value found for path /system/clock/config/timezone-name after delete")
 }

--- a/test/integration/singlepathtest.go
+++ b/test/integration/singlepathtest.go
@@ -66,7 +66,9 @@ func TestSinglePath(t *testing.T) {
 	// Remove the path we added
 	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorDelete)
-	assert.Equal(t, 0, len(extensions))
+	assert.Equal(t, 1, len(extensions))
+	extension = extensions[0].GetRegisteredExt()
+	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	//  Make sure it got removed
 	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, tzPath))

--- a/test/integration/singlestatetest.go
+++ b/test/integration/singlestatetest.go
@@ -40,12 +40,13 @@ func TestSingleState(t *testing.T) {
 	assert.True(t, c != nil, "Fetching client returned nil")
 
 	// Check that the value was correctly retrieved from the device and store in the state cache
-	valueAfter, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, stateControllersPath))
+	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, stateControllersPath))
 	assert.NoError(t, errorAfter)
 	assert.NotEqual(t, "", valueAfter, "Query after state returned an error: %s\n", errorAfter)
 	re := regexp.MustCompile(stateValueRegexp)
 	match := re.MatchString(valueAfter[0].pathDataValue)
 	assert.Equal(t, match, true, "Query for state returned the wrong value: %s\n", valueAfter)
+	assert.Equal(t, len(extensions), 0)
 }
 
 func init() {

--- a/test/integration/singlestatetest.go
+++ b/test/integration/singlestatetest.go
@@ -46,7 +46,7 @@ func TestSingleState(t *testing.T) {
 	re := regexp.MustCompile(stateValueRegexp)
 	match := re.MatchString(valueAfter[0].pathDataValue)
 	assert.Equal(t, match, true, "Query for state returned the wrong value: %s\n", valueAfter)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 }
 
 func init() {

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -102,7 +102,7 @@ func TestSubscribe(t *testing.T) {
 	setPath := makeDevicePath(device, subPath)
 	setPath[0].pathDataValue = subValue
 	setPath[0].pathDataType = StringVal
-	_, errorSet := GNMISet(MakeContext(), c, setPath)
+	_, _, errorSet := GNMISet(MakeContext(), c, setPath)
 	assert.NoError(t, errorSet)
 	var response *gnmi.SubscribeResponse
 
@@ -123,15 +123,17 @@ func TestSubscribe(t *testing.T) {
 	}
 
 	// Check that the value was set correctly
-	valueAfter, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, subPath))
+	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, subPath))
 	assert.NoError(t, errorAfter)
+	assert.Equal(t, len(extensions), 0)
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, subValue, valueAfter[0].pathDataValue,
 		"Query after set returned the wrong value: %s\n", valueAfter)
 
 	// Remove the path we added
-	errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, subPath))
+	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, subPath))
 	assert.NoError(t, errorDelete)
+	assert.Equal(t, len(extensions), 0)
 
 	// Wait for the Update response with delete
 	select {
@@ -150,8 +152,9 @@ func TestSubscribe(t *testing.T) {
 	}
 
 	//  Make sure it got removed
-	valueAfterDelete, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, subPath))
+	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, subPath))
 	assert.NoError(t, errorAfterDelete)
+	assert.Equal(t, len(extensions), 0)
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "",
 		"incorrect value found for path /system/clock/config/timezone-name after delete")
 }
@@ -182,6 +185,9 @@ func buildRequest(path *gnmi.Path, mode gnmi.SubscriptionList_Mode) (*gnmi.Subsc
 }
 
 func validateResponse(t *testing.T, resp *gnmi.SubscribeResponse, device string, delete bool) {
+	//No extension should be provided since the device should be connected.
+	assert.Equal(t, len(resp.Extension), 0)
+
 	switch v := resp.Response.(type) {
 	default:
 		assert.Fail(t, "Unknown type", v)
@@ -212,6 +218,7 @@ func assertUpdateResponse(t *testing.T, response *gnmi.SubscribeResponse_Update,
 	assert.Equal(t, pathResponse.Elem[1].Name, "clock")
 	assert.Equal(t, pathResponse.Elem[2].Name, "config")
 	assert.Equal(t, pathResponse.Elem[3].Name, "timezone-name")
+	assert.Equal(t, response.Update.GetUpdate()[0].Val.GetStringVal(), subValue)
 	assert.Equal(t, response.Update.GetUpdate()[0].Val.GetStringVal(), subValue)
 }
 

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -125,7 +125,7 @@ func TestSubscribe(t *testing.T) {
 	// Check that the value was set correctly
 	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, makeDevicePath(device, subPath))
 	assert.NoError(t, errorAfter)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, subValue, valueAfter[0].pathDataValue,
 		"Query after set returned the wrong value: %s\n", valueAfter)
@@ -133,7 +133,7 @@ func TestSubscribe(t *testing.T) {
 	// Remove the path we added
 	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, subPath))
 	assert.NoError(t, errorDelete)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 
 	// Wait for the Update response with delete
 	select {
@@ -154,7 +154,7 @@ func TestSubscribe(t *testing.T) {
 	//  Make sure it got removed
 	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, subPath))
 	assert.NoError(t, errorAfterDelete)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "",
 		"incorrect value found for path /system/clock/config/timezone-name after delete")
 }
@@ -186,7 +186,7 @@ func buildRequest(path *gnmi.Path, mode gnmi.SubscriptionList_Mode) (*gnmi.Subsc
 
 func validateResponse(t *testing.T, resp *gnmi.SubscribeResponse, device string, delete bool) {
 	//No extension should be provided since the device should be connected.
-	assert.Equal(t, len(resp.Extension), 0)
+	assert.Equal(t, 0, len(resp.Extension))
 
 	switch v := resp.Response.(type) {
 	default:

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-test/pkg/runner"
 	"github.com/onosproject/onos-test/test"
+	"strconv"
 	"testing"
 	"time"
 
@@ -133,7 +134,9 @@ func TestSubscribe(t *testing.T) {
 	// Remove the path we added
 	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, subPath))
 	assert.NoError(t, errorDelete)
-	assert.Equal(t, 0, len(extensions))
+	assert.Equal(t, 1, len(extensions))
+	extension := extensions[0].GetRegisteredExt()
+	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	// Wait for the Update response with delete
 	select {

--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"github.com/onosproject/onos-test/pkg/runner"
 	"github.com/onosproject/onos-test/test"
+	"strconv"
 	"testing"
 
 	"github.com/onosproject/onos-config/pkg/northbound/admin"
@@ -72,7 +73,7 @@ func checkDeviceValue(t *testing.T, deviceGnmiClient client.Impl, devicePaths []
 	deviceValues, extensions, deviceValuesError := GNMIGet(MakeContext(), deviceGnmiClient, devicePaths)
 	assert.NoError(t, deviceValuesError, "GNMI get operation to device returned an error")
 	assert.Equal(t, expectedValue, deviceValues[0].pathDataValue, "Query after set returned the wrong value: %s\n", expectedValue)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 }
 
 func getDeviceGNMIClient(t *testing.T, device string) client.Impl {
@@ -101,7 +102,9 @@ func TestTransaction(t *testing.T) {
 	changeID, extensions, errorSet := GNMISet(MakeContext(), gnmiClient, devicePathsForSet)
 	assert.NoError(t, errorSet)
 	assert.True(t, changeID != "")
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 1, len(extensions))
+	extension := extensions[0].GetRegisteredExt()
+	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	// Check that the values were set correctly
 	var devicePathsForGet = getDevicePaths(devices, paths)
@@ -110,7 +113,7 @@ func TestTransaction(t *testing.T) {
 	assert.NotEqual(t, "", getValuesAfterSet, "Query after set returned an error: %s\n", getValueAfterSetError)
 	assert.Equal(t, value1, getValuesAfterSet[0].pathDataValue, "Query after set returned the wrong value: %s\n", getValuesAfterSet)
 	assert.Equal(t, value2, getValuesAfterSet[1].pathDataValue, "Query after set 2 returned the wrong value: %s\n", getValuesAfterSet)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 
 	// Check that the values are set on the devices
 	device1GnmiClient := getDeviceGNMIClient(t, device1)
@@ -136,5 +139,5 @@ func TestTransaction(t *testing.T) {
 	assert.NotNil(t, rollbackResponse, "Response for get after rollback is nil")
 	assert.Equal(t, "", getValuesAfterRollback[0].pathDataValue, "Query after rollback returned the wrong value: %s\n", getValuesAfterRollback)
 	assert.Equal(t, "", getValuesAfterRollback[1].pathDataValue, "Query after rollback returned the wrong value: %s\n", getValuesAfterRollback)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 }

--- a/test/integration/treepathtest.go
+++ b/test/integration/treepathtest.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"github.com/onosproject/onos-test/pkg/runner"
 	"github.com/onosproject/onos-test/test"
+	"strconv"
 	"testing"
 
 	"github.com/onosproject/onos-test/test/env"
@@ -74,7 +75,9 @@ func TestTreePath(t *testing.T) {
 	// Remove the root path we added
 	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, newRootPath))
 	assert.NoError(t, errorDelete)
-	assert.Equal(t, 0, len(extensions))
+	assert.Equal(t, 1, len(extensions))
+	extension := extensions[0].GetRegisteredExt()
+	assert.Equal(t, extension.Id.String(), strconv.Itoa(100))
 
 	//  Make sure child got removed
 	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, newRootConfigNamePath))

--- a/test/integration/treepathtest.go
+++ b/test/integration/treepathtest.go
@@ -60,7 +60,7 @@ func TestTreePath(t *testing.T) {
 	// Check that the name value was set correctly
 	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, setNamePath)
 	assert.NoError(t, errorAfter)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query name after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, newRootName, valueAfter[0].pathDataValue, "Query name after set returned the wrong value: %s\n", valueAfter)
 
@@ -69,25 +69,25 @@ func TestTreePath(t *testing.T) {
 	assert.NoError(t, errorAfter)
 	assert.NotEqual(t, "", valueAfter, "Query enabled after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, "false", valueAfter[0].pathDataValue, "Query enabled after set returned the wrong value: %s\n", valueAfter)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 
 	// Remove the root path we added
 	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, newRootPath))
 	assert.NoError(t, errorDelete)
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 
 	//  Make sure child got removed
 	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, newRootConfigNamePath))
 	assert.NoError(t, errorAfterDelete)
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "", "New child was not removed")
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 
 	//  Make sure new root got removed
 	valueAfterRootDelete, extensions, errorAfterRootDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, newRootPath))
 	assert.NoError(t, errorAfterRootDelete)
 	assert.Equal(t, valueAfterRootDelete[0].pathDataValue, "",
 		"New root was not removed")
-	assert.Equal(t, len(extensions), 0)
+	assert.Equal(t, 0, len(extensions))
 }
 
 func init() {


### PR DESCRIPTION
Enables the capability to test for extensions.
Currently tests for the absence of extensions in the get/subscribe and the presence of 100 in set operations. 