### PR TITLE
Integration test for doing update and delete paths in the same operation

### DIFF
--- a/test/integration/gnmiutils.go
+++ b/test/integration/gnmiutils.go
@@ -120,7 +120,7 @@ func GNMIDelete(ctx context.Context, c client.Impl, devicePaths []DevicePath) ([
 	return response.Extension, err
 }
 
-// GNMISet generates a SET request on the given client for a path on a device
+// GNMIUpdateAndDelete generates a SET request on the given client for a path on a device
 func GNMIUpdateAndDelete(ctx context.Context, c client.Impl, updatePaths []DevicePath, deletePaths []DevicePath) (string, []*gnmi_ext.Extension, error) {
 	var protoBuilder strings.Builder
 	for _, updatePath := range updatePaths {
@@ -129,7 +129,7 @@ func GNMIUpdateAndDelete(ctx context.Context, c client.Impl, updatePaths []Devic
 	for _, deletePath := range deletePaths {
 		protoBuilder.WriteString(MakeProtoDeletePath(deletePath.deviceName, deletePath.path))
 	}
-	
+
 	setTZRequest := &gpb.SetRequest{}
 	if err := proto.UnmarshalText(protoBuilder.String(), setTZRequest); err != nil {
 		return "", nil, err

--- a/test/integration/gnmiutils.go
+++ b/test/integration/gnmiutils.go
@@ -35,6 +35,8 @@ type DevicePath struct {
 	pathDataValue string
 }
 
+var noPaths = make([]DevicePath, 0)
+
 func convertGetResults(response *gpb.GetResponse) ([]DevicePath, []*gnmi_ext.Extension, error) {
 	entryCount := len(response.Notification)
 	result := make([]DevicePath, entryCount)
@@ -85,43 +87,8 @@ func GNMIGet(ctx context.Context, c client.Impl, paths []DevicePath) ([]DevicePa
 	return convertGetResults(response)
 }
 
-// GNMISet generates a SET request on the given client for a path on a device
-func GNMISet(ctx context.Context, c client.Impl, devicePaths []DevicePath) (string, []*gnmi_ext.Extension, error) {
-	var protoBuilder strings.Builder
-	for _, devicePath := range devicePaths {
-		protoBuilder.WriteString(MakeProtoUpdatePath(devicePath))
-	}
-
-	setTZRequest := &gpb.SetRequest{}
-	if err := proto.UnmarshalText(protoBuilder.String(), setTZRequest); err != nil {
-		return "", nil, err
-	}
-
-	setResult, setError := c.(*gclient.Client).Set(ctx, setTZRequest)
-	if setError != nil {
-		return "", nil, setError
-	}
-	return extractSetTransactionID(setResult), setResult.Extension, nil
-}
-
-// GNMIDelete generates a SET request on the given client to delete a path for a device
-func GNMIDelete(ctx context.Context, c client.Impl, devicePaths []DevicePath) ([]*gnmi_ext.Extension, error) {
-	var protoBuilder strings.Builder
-	for _, devicePath := range devicePaths {
-		protoBuilder.WriteString(MakeProtoDeletePath(devicePath.deviceName, devicePath.path))
-	}
-
-	setTZRequest := &gpb.SetRequest{}
-	if err := proto.UnmarshalText(protoBuilder.String(), setTZRequest); err != nil {
-		return nil, err
-	}
-
-	response, err := c.(*gclient.Client).Set(ctx, setTZRequest)
-	return response.Extension, err
-}
-
-// GNMIUpdateAndDelete generates a SET request on the given client for a path on a device
-func GNMIUpdateAndDelete(ctx context.Context, c client.Impl, updatePaths []DevicePath, deletePaths []DevicePath) (string, []*gnmi_ext.Extension, error) {
+// GNMISet generates a SET request on the given client for update and delete paths on a device
+func GNMISet(ctx context.Context, c client.Impl, updatePaths []DevicePath, deletePaths []DevicePath) (string, []*gnmi_ext.Extension, error) {
 	var protoBuilder strings.Builder
 	for _, updatePath := range updatePaths {
 		protoBuilder.WriteString(MakeProtoUpdatePath(updatePath))

--- a/test/integration/modelstest.go
+++ b/test/integration/modelstest.go
@@ -74,7 +74,7 @@ func TestModels(t *testing.T) {
 				setResult := makeDevicePath(device, path)
 				setResult[0].pathDataValue = value
 				setResult[0].pathDataType = valueType
-				_, _, errorSet := GNMISet(MakeContext(), gnmiClient, setResult)
+				_, _, errorSet := GNMISet(MakeContext(), gnmiClient, setResult, noPaths)
 				assert.NotNil(t, errorSet, "Set operation for %s does not generate an error", description)
 				assert.Contains(t, errorSet.Error(),
 					expectedError,

--- a/test/integration/singlepathtest.go
+++ b/test/integration/singlepathtest.go
@@ -50,7 +50,7 @@ func TestSinglePath(t *testing.T) {
 	setPath := makeDevicePath(device, tzPath)
 	setPath[0].pathDataValue = tzValue
 	setPath[0].pathDataType = StringVal
-	_, extensions, errorSet := GNMISet(MakeContext(), c, setPath)
+	_, extensions, errorSet := GNMISet(MakeContext(), c, setPath, noPaths)
 	assert.NoError(t, errorSet)
 	assert.Equal(t, 1, len(extensions))
 	extension := extensions[0].GetRegisteredExt()
@@ -64,7 +64,7 @@ func TestSinglePath(t *testing.T) {
 	assert.Equal(t, tzValue, valueAfter[0].pathDataValue, "Query after set returned the wrong value: %s\n", valueAfter)
 
 	// Remove the path we added
-	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, tzPath))
+	_, extensions, errorDelete := GNMISet(MakeContext(), c, noPaths, makeDevicePath(device, tzPath))
 	assert.NoError(t, errorDelete)
 	assert.Equal(t, 1, len(extensions))
 	extension = extensions[0].GetRegisteredExt()

--- a/test/integration/subscribetest.go
+++ b/test/integration/subscribetest.go
@@ -103,7 +103,7 @@ func TestSubscribe(t *testing.T) {
 	setPath := makeDevicePath(device, subPath)
 	setPath[0].pathDataValue = subValue
 	setPath[0].pathDataType = StringVal
-	_, _, errorSet := GNMISet(MakeContext(), c, setPath)
+	_, _, errorSet := GNMISet(MakeContext(), c, setPath, noPaths)
 	assert.NoError(t, errorSet)
 	var response *gnmi.SubscribeResponse
 
@@ -132,7 +132,7 @@ func TestSubscribe(t *testing.T) {
 		"Query after set returned the wrong value: %s\n", valueAfter)
 
 	// Remove the path we added
-	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, subPath))
+	_, extensions, errorDelete := GNMISet(MakeContext(), c, noPaths, makeDevicePath(device, subPath))
 	assert.NoError(t, errorDelete)
 	assert.Equal(t, 1, len(extensions))
 	extension := extensions[0].GetRegisteredExt()

--- a/test/integration/transactiontest.go
+++ b/test/integration/transactiontest.go
@@ -99,7 +99,7 @@ func TestTransaction(t *testing.T) {
 
 	// Set values
 	var devicePathsForSet = getDevicePathsWithValues(devices, paths, values)
-	changeID, extensions, errorSet := GNMISet(MakeContext(), gnmiClient, devicePathsForSet)
+	changeID, extensions, errorSet := GNMISet(MakeContext(), gnmiClient, devicePathsForSet, noPaths)
 	assert.NoError(t, errorSet)
 	assert.True(t, changeID != "")
 	assert.Equal(t, 1, len(extensions))

--- a/test/integration/treepathtest.go
+++ b/test/integration/treepathtest.go
@@ -47,7 +47,7 @@ func TestTreePath(t *testing.T) {
 	setNamePath := []DevicePath{
 		{deviceName: device, path: newRootConfigNamePath, pathDataValue: newRootName, pathDataType: StringVal},
 	}
-	_, _, errorSet := GNMISet(MakeContext(), c, setNamePath)
+	_, _, errorSet := GNMISet(MakeContext(), c, setNamePath, noPaths)
 	assert.NoError(t, errorSet)
 
 	// Set values using gNMI client
@@ -55,7 +55,7 @@ func TestTreePath(t *testing.T) {
 		{deviceName: device, path: newRootDescriptionPath, pathDataValue: newDescription, pathDataType: StringVal},
 		{deviceName: device, path: newRootEnabledPath, pathDataValue: "false", pathDataType: BoolVal},
 	}
-	_, _, errorSet = GNMISet(MakeContext(), c, setPath)
+	_, _, errorSet = GNMISet(MakeContext(), c, setPath, noPaths)
 	assert.NoError(t, errorSet)
 
 	// Check that the name value was set correctly
@@ -73,7 +73,7 @@ func TestTreePath(t *testing.T) {
 	assert.Equal(t, 0, len(extensions))
 
 	// Remove the root path we added
-	extensions, errorDelete := GNMIDelete(MakeContext(), c, makeDevicePath(device, newRootPath))
+	_, extensions, errorDelete := GNMISet(MakeContext(), c, noPaths, makeDevicePath(device, newRootPath))
 	assert.NoError(t, errorDelete)
 	assert.Equal(t, 1, len(extensions))
 	extension := extensions[0].GetRegisteredExt()

--- a/test/integration/updatedeletetest.go
+++ b/test/integration/updatedeletetest.go
@@ -42,13 +42,11 @@ func TestUpdateDelete(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, c != nil, "Fetching client returned nil")
 
-	noPaths := make([]DevicePath, 0)
-
 	// Create interface tree using gNMI client
 	setNamePath := []DevicePath{
 		{deviceName: device, path: udtestNamePath, pathDataValue: udtestNameValue, pathDataType: StringVal},
 	}
-	_, _, errorSet := GNMIUpdateAndDelete(MakeContext(), c, setNamePath, noPaths)
+	_, _, errorSet := GNMISet(MakeContext(), c, setNamePath, noPaths)
 	assert.NoError(t, errorSet)
 
 	// Set initial values for Enabled and Description using gNMI client
@@ -56,7 +54,7 @@ func TestUpdateDelete(t *testing.T) {
 		{deviceName: device, path: udtestEnabledPath, pathDataValue: "true", pathDataType: BoolVal},
 		{deviceName: device, path: udtestDescriptionPath, pathDataValue: udtestDescriptionValue, pathDataType: StringVal},
 	}
-	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, setInitialValuesPath, noPaths)
+	_, _, errorSet = GNMISet(MakeContext(), c, setInitialValuesPath, noPaths)
 	assert.NoError(t, errorSet)
 
 	// Update Enabled, delete Description using gNMI client
@@ -66,7 +64,7 @@ func TestUpdateDelete(t *testing.T) {
 	deleteDescriptionPath := []DevicePath{
 		{deviceName: device, path: udtestDescriptionPath},
 	}
-	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, updateEnabledPath, deleteDescriptionPath)
+	_, _, errorSet = GNMISet(MakeContext(), c, updateEnabledPath, deleteDescriptionPath)
 	assert.NoError(t, errorSet)
 
 	// Check that the Enabled value is set correctly

--- a/test/integration/updatedeletetest.go
+++ b/test/integration/updatedeletetest.go
@@ -1,0 +1,86 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"github.com/onosproject/onos-test/pkg/runner"
+	"github.com/onosproject/onos-test/test"
+	"testing"
+
+	"github.com/onosproject/onos-test/test/env"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	udtestRootPath  = "/interfaces/interface[name=test]"
+	udtestNamePath     = udtestRootPath + "/config/name"
+	udtestEnabledPath = udtestRootPath + "/config/enabled"
+	udtestDescriptionPath = udtestRootPath + "/config/description"
+	udtestNameValue    = "test"
+	udtestDescriptionValue = "description"
+)
+
+// TestTreePath tests create/set/delete of a tree of GNMI paths to a single device
+func TestUpdateDelete(t *testing.T) {
+	// Get the first configured device from the environment.
+	device := env.GetDevices()[0]
+
+	// Make a GNMI client to use for requests
+	c, err := env.NewGnmiClient(MakeContext(), "")
+	assert.NoError(t, err)
+	assert.True(t, c != nil, "Fetching client returned nil")
+
+	// Create interface tree using gNMI client
+	setNamePath := []DevicePath{
+		{deviceName: device, path: udtestNamePath, pathDataValue: udtestNameValue, pathDataType: StringVal},
+	}
+	_, _, errorSet := GNMISet(MakeContext(), c, setNamePath)
+	assert.NoError(t, errorSet)
+
+	// Set first path using gNMI client
+	setEnabledPath := []DevicePath{
+		{deviceName: device, path: udtestEnabledPath, pathDataValue: "true", pathDataType: BoolVal},
+		{deviceName: device, path: udtestDescriptionPath, pathDataValue: udtestDescriptionValue, pathDataType: StringVal},
+	}
+	_, _, errorSet = GNMISet(MakeContext(), c, setEnabledPath)
+	assert.NoError(t, errorSet)
+
+	// Set path2, delete path 1 using gNMI client
+	updatePath := []DevicePath{
+		{deviceName: device, path: udtestEnabledPath, pathDataValue: "false", pathDataType: BoolVal},
+	}
+	deletePath := []DevicePath{
+		{deviceName: device, path: udtestDescriptionPath},
+	}
+	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, updatePath, deletePath)
+	assert.NoError(t, errorSet)
+
+	// Check that the name value is still set correctly
+	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, updatePath)
+	assert.NoError(t, errorAfter)
+	assert.Equal(t, 0, len(extensions))
+	assert.NotEqual(t, "", valueAfter, "Query name after set returned an error: %s\n", errorAfter)
+	assert.Equal(t, "false", valueAfter[0].pathDataValue, "Query name after set returned the wrong value: %s\n", valueAfter)
+
+	//  Make sure deleted value got removed
+	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, udtestDescriptionPath))
+	assert.NoError(t, errorAfterDelete)
+	assert.Equal(t, valueAfterDelete[0].pathDataValue, "", "New child was not removed")
+	assert.Equal(t, 0, len(extensions))
+}
+
+func init() {
+	test.Registry.RegisterTest("update-delete", TestUpdateDelete, []*runner.TestSuite{AllTests, IntegrationTests})
+}

--- a/test/integration/updatedeletetest.go
+++ b/test/integration/updatedeletetest.go
@@ -32,7 +32,7 @@ const (
 	udtestDescriptionValue = "description"
 )
 
-// TestUpdateDelete tests create/set/delete of a tree of GNMI paths to a single device
+// TestUpdateDelete tests update and delete paths in a single GNMI request
 func TestUpdateDelete(t *testing.T) {
 	// Get the first configured device from the environment.
 	device := env.GetDevices()[0]
@@ -46,7 +46,7 @@ func TestUpdateDelete(t *testing.T) {
 	setNamePath := []DevicePath{
 		{deviceName: device, path: udtestNamePath, pathDataValue: udtestNameValue, pathDataType: StringVal},
 	}
-	_, _, errorSet := GNMISet(MakeContext(), c, setNamePath)
+	_, _, errorSet := GNMIUpdateAndDelete(MakeContext(), c, setNamePath, nil)
 	assert.NoError(t, errorSet)
 
 	// Set first path using gNMI client
@@ -54,7 +54,7 @@ func TestUpdateDelete(t *testing.T) {
 		{deviceName: device, path: udtestEnabledPath, pathDataValue: "true", pathDataType: BoolVal},
 		{deviceName: device, path: udtestDescriptionPath, pathDataValue: udtestDescriptionValue, pathDataType: StringVal},
 	}
-	_, _, errorSet = GNMISet(MakeContext(), c, setEnabledPath)
+	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, setEnabledPath, nil)
 	assert.NoError(t, errorSet)
 
 	// Set path2, delete path 1 using gNMI client

--- a/test/integration/updatedeletetest.go
+++ b/test/integration/updatedeletetest.go
@@ -24,15 +24,15 @@ import (
 )
 
 const (
-	udtestRootPath  = "/interfaces/interface[name=test]"
-	udtestNamePath     = udtestRootPath + "/config/name"
-	udtestEnabledPath = udtestRootPath + "/config/enabled"
-	udtestDescriptionPath = udtestRootPath + "/config/description"
-	udtestNameValue    = "test"
+	udtestRootPath         = "/interfaces/interface[name=test]"
+	udtestNamePath         = udtestRootPath + "/config/name"
+	udtestEnabledPath      = udtestRootPath + "/config/enabled"
+	udtestDescriptionPath  = udtestRootPath + "/config/description"
+	udtestNameValue        = "test"
 	udtestDescriptionValue = "description"
 )
 
-// TestTreePath tests create/set/delete of a tree of GNMI paths to a single device
+// TestUpdateDelete tests create/set/delete of a tree of GNMI paths to a single device
 func TestUpdateDelete(t *testing.T) {
 	// Get the first configured device from the environment.
 	device := env.GetDevices()[0]

--- a/test/integration/updatedeletetest.go
+++ b/test/integration/updatedeletetest.go
@@ -42,13 +42,12 @@ func TestUpdateDelete(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, c != nil, "Fetching client returned nil")
 
+	noPaths := make([]DevicePath, 0)
+
 	// Create interface tree using gNMI client
 	setNamePath := []DevicePath{
 		{deviceName: device, path: udtestNamePath, pathDataValue: udtestNameValue, pathDataType: StringVal},
 	}
-
-	noPaths := make([]DevicePath, 0)
-
 	_, _, errorSet := GNMIUpdateAndDelete(MakeContext(), c, setNamePath, noPaths)
 	assert.NoError(t, errorSet)
 

--- a/test/integration/updatedeletetest.go
+++ b/test/integration/updatedeletetest.go
@@ -46,35 +46,38 @@ func TestUpdateDelete(t *testing.T) {
 	setNamePath := []DevicePath{
 		{deviceName: device, path: udtestNamePath, pathDataValue: udtestNameValue, pathDataType: StringVal},
 	}
-	_, _, errorSet := GNMIUpdateAndDelete(MakeContext(), c, setNamePath, nil)
+
+	noPaths := make([]DevicePath, 0)
+
+	_, _, errorSet := GNMIUpdateAndDelete(MakeContext(), c, setNamePath, noPaths)
 	assert.NoError(t, errorSet)
 
-	// Set first path using gNMI client
-	setEnabledPath := []DevicePath{
+	// Set initial values for Enabled and Description using gNMI client
+	setInitialValuesPath := []DevicePath{
 		{deviceName: device, path: udtestEnabledPath, pathDataValue: "true", pathDataType: BoolVal},
 		{deviceName: device, path: udtestDescriptionPath, pathDataValue: udtestDescriptionValue, pathDataType: StringVal},
 	}
-	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, setEnabledPath, nil)
+	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, setInitialValuesPath, noPaths)
 	assert.NoError(t, errorSet)
 
-	// Set path2, delete path 1 using gNMI client
-	updatePath := []DevicePath{
+	// Update Enabled, delete Description using gNMI client
+	updateEnabledPath := []DevicePath{
 		{deviceName: device, path: udtestEnabledPath, pathDataValue: "false", pathDataType: BoolVal},
 	}
-	deletePath := []DevicePath{
+	deleteDescriptionPath := []DevicePath{
 		{deviceName: device, path: udtestDescriptionPath},
 	}
-	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, updatePath, deletePath)
+	_, _, errorSet = GNMIUpdateAndDelete(MakeContext(), c, updateEnabledPath, deleteDescriptionPath)
 	assert.NoError(t, errorSet)
 
-	// Check that the name value is still set correctly
-	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, updatePath)
+	// Check that the Enabled value is set correctly
+	valueAfter, extensions, errorAfter := GNMIGet(MakeContext(), c, updateEnabledPath)
 	assert.NoError(t, errorAfter)
 	assert.Equal(t, 0, len(extensions))
 	assert.NotEqual(t, "", valueAfter, "Query name after set returned an error: %s\n", errorAfter)
 	assert.Equal(t, "false", valueAfter[0].pathDataValue, "Query name after set returned the wrong value: %s\n", valueAfter)
 
-	//  Make sure deleted value got removed
+	//  Make sure Description got removed
 	valueAfterDelete, extensions, errorAfterDelete := GNMIGet(MakeContext(), c, makeDevicePath(device, udtestDescriptionPath))
 	assert.NoError(t, errorAfterDelete)
 	assert.Equal(t, valueAfterDelete[0].pathDataValue, "", "New child was not removed")


### PR DESCRIPTION
This PR introduces a new integration test that tests updating a path and removing a path in the same GNMI request. This implements issue #801 in onos-config