### PR TITLE
Add new onit CLI implementation

### DIFF
--- a/cmd/onit-new/main.go
+++ b/cmd/onit-new/main.go
@@ -12,13 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package setup
+package main
 
-// AppSetup is an interface for setting up an application
-type AppSetup interface {
-	Setup
-	ServiceTypeSetup
+import (
+	"fmt"
+	"github.com/onosproject/onos-test/pkg/new/onit/cli"
+	"os"
 
-	// Nodes sets the number of application nodes
-	Nodes(nodes int) AppSetup
+	_ "github.com/onosproject/onos-test/test/api"
+	_ "github.com/onosproject/onos-test/test/atomix"
+	_ "github.com/onosproject/onos-test/test/config"
+	_ "github.com/onosproject/onos-test/test/integration"
+	_ "github.com/onosproject/onos-test/test/topo"
+)
+
+func main() {
+	cmd := cli.GetRootCommand()
+	if err := cmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 }

--- a/pkg/new/kube/kubeapi.go
+++ b/pkg/new/kube/kubeapi.go
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kubetest
+package kube
 
 import (
 	"github.com/onosproject/onos-test/pkg/new/util/k8s"
+	"github.com/onosproject/onos-test/pkg/new/util/random"
 	"k8s.io/client-go/rest"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// getKubeAPI returns the Kubernetes API for the current environment
-func getKubeAPI() KubeAPI {
-	namespace := os.Getenv(testNamespaceEnv)
+const testNamespaceEnv = "TEST_NAMESPACE"
+
+// GetAPI returns the Kubernetes API for the given namespace
+func GetAPI(namespace string) API {
 	config, err := k8s.GetRestConfig()
 	if err != nil {
 		panic(err)
@@ -39,14 +41,23 @@ func getKubeAPI() KubeAPI {
 	}
 }
 
-// KubeAPIProvider is an interface for types to provide the Kubernetes API
-type KubeAPIProvider interface {
-	// KubeAPI returns the KubeAPI
-	KubeAPI() KubeAPI
+// GetAPIFromEnv returns the Kubernetes API for the current environment
+func GetAPIFromEnv() API {
+	namespace := os.Getenv(testNamespaceEnv)
+	if namespace == "" {
+		namespace = random.NewPetName(2)
+	}
+	return GetAPI(namespace)
 }
 
-// KubeAPI exposes the Kubernetes API to tests
-type KubeAPI interface {
+// APIProvider is an interface for types to provide the Kubernetes API
+type APIProvider interface {
+	// API returns the API
+	API() API
+}
+
+// API exposes the Kubernetes API to tests
+type API interface {
 	// Namespace returns the Kubernetes namespace
 	Namespace() string
 

--- a/pkg/new/kubetest/benchmark.go
+++ b/pkg/new/kubetest/benchmark.go
@@ -16,6 +16,7 @@ package kubetest
 
 import (
 	"fmt"
+	"github.com/onosproject/onos-test/pkg/new/kube"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"reflect"
@@ -29,23 +30,23 @@ var allBenchmarksFilter = func(_, _ string) (bool, error) { return true, nil }
 // Benchmarks is a suite of benchmarks run on a single cluster
 type Benchmarks struct {
 	*assert.Assertions
-	kube KubeAPI
+	kube kube.API
 }
 
-// KubeAPI returns the Kubernetes API
-func (s *Benchmarks) KubeAPI() KubeAPI {
+// API returns the Kubernetes API
+func (s *Benchmarks) API() kube.API {
 	return s.kube
 }
 
 // Run runs the benchmarks
 func (s *Benchmarks) Run(b *testing.B) {
-	s.kube = getKubeAPI()
+	s.kube = kube.GetAPIFromEnv()
 	RunBenchmarks(b, s)
 }
 
 // BenchmarkSuite is an identifier interface for benchmark suites
 type BenchmarkSuite interface {
-	KubeAPIProvider
+	kube.APIProvider
 
 	// Run runs the benchmark suite
 	Run(b *testing.B)

--- a/pkg/new/kubetest/cli.go
+++ b/pkg/new/kubetest/cli.go
@@ -16,7 +16,7 @@ package kubetest
 
 import (
 	"fmt"
-	"github.com/dustinkirkland/golang-petname"
+	"github.com/onosproject/onos-test/pkg/new/util/random"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"math/rand"
@@ -57,7 +57,7 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 
 	test := &TestConfig{
-		TestID:     newTestID(),
+		TestID:     random.NewPetName(2),
 		Type:       TestTypeTest,
 		Image:      image,
 		Suite:      suite,
@@ -65,7 +65,7 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 		PullPolicy: corev1.PullPolicy(pullPolicy),
 	}
 
-	runner, err := newTestRunner(test)
+	runner, err := NewTestRunner(test)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func runBenchCommand(cmd *cobra.Command, _ []string) error {
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 
 	test := &TestConfig{
-		TestID:     newTestID(),
+		TestID:     random.NewPetName(2),
 		Type:       TestTypeBenchmark,
 		Image:      image,
 		Suite:      suite,
@@ -102,7 +102,7 @@ func runBenchCommand(cmd *cobra.Command, _ []string) error {
 		PullPolicy: corev1.PullPolicy(pullPolicy),
 	}
 
-	runner, err := newTestRunner(test)
+	runner, err := NewTestRunner(test)
 	if err != nil {
 		return err
 	}
@@ -139,9 +139,4 @@ func runRunCommand(cmd *cobra.Command, args []string) error {
 
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
-}
-
-// newTestID returns a new test ID
-func newTestID() string {
-	return petname.Generate(2, "-")
 }

--- a/pkg/new/kubetest/runner.go
+++ b/pkg/new/kubetest/runner.go
@@ -60,8 +60,8 @@ type TestRecord struct {
 	ExitCode int
 }
 
-// newTestRunner returns a new test runner
-func newTestRunner(test *TestConfig) (*TestRunner, error) {
+// NewTestRunner returns a new test runner
+func NewTestRunner(test *TestConfig) (*TestRunner, error) {
 	client, err := k8s.GetClientset()
 	if err != nil {
 		return nil, err

--- a/pkg/new/kubetest/test.go
+++ b/pkg/new/kubetest/test.go
@@ -16,6 +16,7 @@ package kubetest
 
 import (
 	"fmt"
+	"github.com/onosproject/onos-test/pkg/new/kube"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"reflect"
@@ -29,23 +30,23 @@ var allTestsFilter = func(_, _ string) (bool, error) { return true, nil }
 // Tests is a suite of tests run on a single cluster
 type Tests struct {
 	*assert.Assertions
-	kube KubeAPI
+	kube kube.API
 }
 
-// KubeAPI returns the Kubernetes API
-func (s *Tests) KubeAPI() KubeAPI {
+// API returns the Kubernetes API
+func (s *Tests) API() kube.API {
 	return s.kube
 }
 
 // Run runs the tests
 func (s *Tests) Run(t *testing.T) {
-	s.kube = getKubeAPI()
+	s.kube = kube.GetAPIFromEnv()
 	RunTests(t, s)
 }
 
 // TestSuite is an identifier interface for test suites
 type TestSuite interface {
-	KubeAPIProvider
+	kube.APIProvider
 
 	// Run runs the test suite
 	Run(t *testing.T)

--- a/pkg/new/onit/benchmark.go
+++ b/pkg/new/onit/benchmark.go
@@ -42,6 +42,6 @@ type SetupONOSBenchmarkSuite interface {
 // setupONOSBenchmark sets up the ONOS cluster for the given benchmark suite
 func setupONOSBenchmark(b BenchmarkSuite) {
 	if setupONOS, ok := b.(SetupONOSBenchmarkSuite); ok {
-		setupONOS.SetupONOSBenchmarkSuite(setup.New(b.KubeAPI()))
+		setupONOS.SetupONOSBenchmarkSuite(setup.New(b.API()))
 	}
 }

--- a/pkg/new/onit/cli/add.go
+++ b/pkg/new/onit/cli/add.go
@@ -1,0 +1,181 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/onosproject/onos-test/pkg/new/kube"
+	"github.com/onosproject/onos-test/pkg/new/onit/env"
+	"github.com/onosproject/onos-test/pkg/new/util/random"
+
+	"github.com/onosproject/onos-test/pkg/onit/setup"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	addExample = `
+		# Add a simulator with a given name
+		onit add simulator simulator-1
+
+		# Add a network of stratum switches that emulates a linear network topology with two nodes
+		onit add network stratum-linear -- --topo linear,2
+	   
+		# Add latest version of an application 
+		onit add app onos-ztp --image onosproject/onos-ztp:latest --image-pull-policy "Always" `
+)
+
+// getAddCommand returns a cobra "add" command for adding resources to the cluster
+func getAddCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "add {simulator,network} [args]",
+		Short:   "Add resources to the cluster",
+		Example: addExample,
+	}
+	cmd.AddCommand(getAddSimulatorCommand())
+	cmd.AddCommand(getAddNetworkCommand())
+	cmd.AddCommand(getAddAppCommand())
+	return cmd
+}
+
+// getAddNetworkCommand returns a cobra command for deploying a stratum network
+func getAddNetworkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "network [name]",
+		Short: "Add a stratum network to the test cluster",
+		Args:  cobra.MaximumNArgs(10),
+		RunE:  runAddNetworkCommand,
+	}
+
+	cmd.Flags().StringP("image", "i", defaultMininetImage, "the image to deploy")
+	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
+	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the simulator")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+}
+
+func runAddNetworkCommand(cmd *cobra.Command, args []string) error {
+	var networkID string
+	if len(args) > 0 {
+		networkID = args[0]
+	}
+	if networkID == "" {
+		networkID = random.NewPetName(2)
+	}
+
+	cluster, _ := cmd.Flags().GetString("cluster")
+	image, _ := cmd.Flags().GetString("image")
+	imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
+	pullPolicy := corev1.PullPolicy(imagePullPolicy)
+
+	kubeAPI := kube.GetAPI(cluster)
+	env := env.New(kubeAPI)
+	return env.Networks().
+		Add(networkID).
+		Using().
+		Image(image).
+		PullPolicy(pullPolicy).
+		Setup()
+}
+
+// getAddSimulatorCommand returns a cobra command for deploying a device simulator
+func getAddSimulatorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "simulator [name]",
+		Short: "Add a device simulator to the test cluster",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runAddSimulatorCommand,
+	}
+
+	cmd.Flags().StringP("image", "i", defaultSimulatorImage, "the image to deploy")
+	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
+	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the simulator")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+}
+
+func runAddSimulatorCommand(cmd *cobra.Command, args []string) error {
+	var deviceID string
+	if len(args) > 0 {
+		deviceID = args[0]
+	}
+	if deviceID == "" {
+		deviceID = random.NewPetName(2)
+	}
+
+	cluster, _ := cmd.Flags().GetString("cluster")
+	image, _ := cmd.Flags().GetString("image")
+	imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
+	pullPolicy := corev1.PullPolicy(imagePullPolicy)
+
+	kubeAPI := kube.GetAPI(cluster)
+	env := env.New(kubeAPI)
+	return env.Simulators().
+		Add(deviceID).
+		Using().
+		Image(image).
+		PullPolicy(pullPolicy).
+		Setup()
+}
+
+// getAddSimulatorCommand returns a cobra command for deploying a device simulator
+func getAddAppCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "app image-name [name]",
+		Short: "Add an app to the test cluster",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runAddAppCommand,
+	}
+
+	cmd.Flags().StringP("image", "i", "", "the image to deploy")
+	_ = cmd.MarkFlagRequired("image")
+	cmd.Flags().IntP("nodes", "n", 1, "the number of nodes to deploy")
+	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
+	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the app")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+}
+
+func runAddAppCommand(cmd *cobra.Command, args []string) error {
+	var appID string
+	if len(args) > 0 {
+		appID = args[0]
+	}
+	if appID == "" {
+		appID = random.NewPetName(2)
+	}
+
+	cluster, _ := cmd.Flags().GetString("cluster")
+	image, _ := cmd.Flags().GetString("image")
+	nodes, _ := cmd.Flags().GetInt("nodes")
+	imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
+	pullPolicy := corev1.PullPolicy(imagePullPolicy)
+
+	kubeAPI := kube.GetAPI(cluster)
+	env := env.New(kubeAPI)
+	return env.Apps().
+		Add(appID).
+		Nodes(nodes).
+		Using().
+		Image(image).
+		PullPolicy(pullPolicy).
+		Setup()
+}

--- a/pkg/new/onit/cli/add.go
+++ b/pkg/new/onit/cli/add.go
@@ -62,9 +62,6 @@ func getAddNetworkCommand() *cobra.Command {
 	cmd.Flags().StringP("image", "i", defaultMininetImage, "the image to deploy")
 	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
 	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the simulator")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	return cmd
 }
 
@@ -104,9 +101,6 @@ func getAddSimulatorCommand() *cobra.Command {
 	cmd.Flags().StringP("image", "i", defaultSimulatorImage, "the image to deploy")
 	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
 	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the simulator")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	return cmd
 }
 
@@ -148,9 +142,6 @@ func getAddAppCommand() *cobra.Command {
 	cmd.Flags().IntP("nodes", "n", 1, "the number of nodes to deploy")
 	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
 	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the app")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	return cmd
 }
 

--- a/pkg/new/onit/cli/cluster.go
+++ b/pkg/new/onit/cli/cluster.go
@@ -1,0 +1,388 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"errors"
+	"github.com/ghodss/yaml"
+	"github.com/onosproject/onos-test/pkg/new/kubetest"
+	"github.com/onosproject/onos-test/pkg/new/util/logging"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"time"
+)
+
+// clusterSetup handles setting up and tearing down clusters from the CLI
+type clusterSetup struct {
+	clusterID string
+	client    *kubernetes.Clientset
+}
+
+func (c *clusterSetup) setup() error {
+	return c.setupNamespace()
+}
+
+func (c *clusterSetup) teardown() error {
+	return c.teardownNamespace()
+}
+
+// setupNamespace sets up the test namespace
+func (c *clusterSetup) setupNamespace() error {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: c.clusterID,
+		},
+	}
+	step := logging.NewStep(c.clusterID, "Create worker namespace")
+	step.Start()
+	_, err := c.client.CoreV1().Namespaces().Create(ns)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		step.Fail(err)
+		return err
+	}
+	step.Complete()
+	return c.setupRBAC()
+}
+
+// setupRBAC sets up role based access controls for the cluster
+func (c *clusterSetup) setupRBAC() error {
+	step := logging.NewStep(c.clusterID, "Set up RBAC")
+	step.Start()
+	if err := c.createClusterRole(); err != nil {
+		step.Fail(err)
+		return err
+	}
+	if err := c.createClusterRoleBinding(); err != nil {
+		step.Fail(err)
+		return err
+	}
+	if err := c.createServiceAccount(); err != nil {
+		step.Fail(err)
+		return err
+	}
+	step.Complete()
+	return nil
+}
+
+// createClusterRole creates the ClusterRole required by the Atomix controller and tests if not yet created
+func (c *clusterSetup) createClusterRole() error {
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.clusterID,
+			Namespace: c.clusterID,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"pods",
+					"pods/log",
+					"pods/exec",
+					"services",
+					"endpoints",
+					"persistentvolumeclaims",
+					"events",
+					"configmaps",
+					"secrets",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"",
+				},
+				Resources: []string{
+					"namespaces",
+				},
+				Verbs: []string{
+					"get",
+				},
+			},
+			{
+				APIGroups: []string{
+					"apps",
+				},
+				Resources: []string{
+					"deployments",
+					"daemonsets",
+					"replicasets",
+					"statefulsets",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"policy",
+				},
+				Resources: []string{
+					"poddisruptionbudgets",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"k8s.atomix.io",
+				},
+				Resources: []string{
+					"*",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+		},
+	}
+	_, err := c.client.RbacV1().ClusterRoles().Create(role)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// createClusterRoleBinding creates the ClusterRoleBinding required by the test manager
+func (c *clusterSetup) createClusterRoleBinding() error {
+	roleBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.clusterID,
+			Namespace: c.clusterID,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      c.clusterID,
+				Namespace: c.clusterID,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     c.clusterID,
+			APIGroup: "rbac.authorization.k8s.io",
+		},
+	}
+	_, err := c.client.RbacV1().ClusterRoleBindings().Create(roleBinding)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// createServiceAccount creates a ServiceAccount used by the test manager
+func (c *clusterSetup) createServiceAccount() error {
+	serviceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.clusterID,
+			Namespace: c.clusterID,
+		},
+	}
+	_, err := c.client.CoreV1().ServiceAccounts(c.clusterID).Create(serviceAccount)
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// startTest starts running a test job
+func (c *clusterSetup) startTest(test *kubetest.TestConfig) error {
+	if err := c.createTestConfig(test); err != nil {
+		return err
+	}
+	if err := c.createTestJob(test); err != nil {
+		return err
+	}
+	if err := c.awaitTestJobRunning(test); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createTestConfig creates a ConfigMap for the test configuration
+func (c *clusterSetup) createTestConfig(test *kubetest.TestConfig) error {
+	data, err := yaml.Marshal(test)
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      test.TestID,
+			Namespace: c.clusterID,
+		},
+		Data: map[string]string{
+			"config.yaml": string(data),
+		},
+	}
+	_, err = c.client.CoreV1().ConfigMaps(c.clusterID).Create(cm)
+	return err
+}
+
+// createTestJob creates the job to run tests
+func (c *clusterSetup) createTestJob(test *kubetest.TestConfig) error {
+	zero := int32(0)
+	one := int32(1)
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      test.TestID,
+			Namespace: c.clusterID,
+			Annotations: map[string]string{
+				"test-id": test.TestID,
+				"suite":   test.Suite,
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism:  &one,
+			Completions:  &one,
+			BackoffLimit: &zero,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"type": string(test.Type),
+						"test": test.TestID,
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: c.clusterID,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:            "test",
+							Image:           test.Image,
+							ImagePullPolicy: test.PullPolicy,
+							Env: []corev1.EnvVar{
+								{
+									Name:  "TEST_CONTEXT",
+									Value: "worker",
+								},
+								{
+									Name:  "TEST_NAMESPACE",
+									Value: c.clusterID,
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "config",
+									MountPath: "/config",
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "config",
+							VolumeSource: corev1.VolumeSource{
+								ConfigMap: &corev1.ConfigMapVolumeSource{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: test.TestID,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if test.Timeout > 0 {
+		timeoutSeconds := int64(test.Timeout / time.Second)
+		job.Spec.ActiveDeadlineSeconds = &timeoutSeconds
+	}
+	_, err := c.client.BatchV1().Jobs(c.clusterID).Create(job)
+	return err
+}
+
+// awaitTestJobRunning blocks until the test job creates a pod in the RUNNING state
+func (c *clusterSetup) awaitTestJobRunning(test *kubetest.TestConfig) error {
+	for {
+		pod, err := c.getPod(test)
+		if err != nil {
+			return err
+		} else if pod != nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// awaitTestJobComplete blocks until the test job is complete
+func (c *clusterSetup) awaitTestJobComplete(test *kubetest.TestConfig) error {
+	for {
+		pod, err := c.getPod(test)
+		if err != nil {
+			return err
+		} else if pod == nil {
+			return errors.New("cannot locate test pod")
+		}
+		state := pod.Status.ContainerStatuses[0].State
+		if state.Terminated != nil {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// getStatus gets the status message and exit code of the given pod
+func (c *clusterSetup) getStatus(test *kubetest.TestConfig) (string, int, error) {
+	pod, err := c.getPod(test)
+	if err != nil {
+		return "", 0, err
+	} else if pod == nil {
+		return "", 0, errors.New("cannot locate test pod")
+	}
+	state := pod.Status.ContainerStatuses[0].State
+	if state.Terminated != nil {
+		return state.Terminated.Message, int(state.Terminated.ExitCode), nil
+	}
+	return "", 0, errors.New("test job is not complete")
+}
+
+// getPod finds the Pod for the given test
+func (c *clusterSetup) getPod(test *kubetest.TestConfig) (*corev1.Pod, error) {
+	pods, err := c.client.CoreV1().Pods(c.clusterID).List(metav1.ListOptions{
+		LabelSelector: "test=" + test.TestID,
+	})
+	if err != nil {
+		return nil, err
+	} else if len(pods.Items) > 0 {
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodRunning && len(pod.Status.ContainerStatuses) > 0 && pod.Status.ContainerStatuses[0].Ready {
+				return &pod, nil
+			}
+		}
+		for _, pod := range pods.Items {
+			if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+				return &pod, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+// teardownNamespace tears down the cluster namespace
+func (c *clusterSetup) teardownNamespace() error {
+	return c.client.CoreV1().Namespaces().Delete(c.clusterID, &metav1.DeleteOptions{})
+}

--- a/pkg/new/onit/cli/create.go
+++ b/pkg/new/onit/cli/create.go
@@ -1,0 +1,142 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/onosproject/onos-test/pkg/new/kube"
+	"github.com/onosproject/onos-test/pkg/new/util/k8s"
+	"github.com/onosproject/onos-test/pkg/new/util/random"
+
+	"github.com/onosproject/onos-test/pkg/new/onit/setup"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	createExample = `
+		# Create a cluster with a given name that contains one instance of each subsystem (e.g. onos-config, onos-topo)
+		onit create cluster onit-cluster-1 
+
+		# Create a cluster that contains two instances of onos-config subsystem and two instances of onos-topo subsystem
+		onit-create-cluster onit-cluster-2 --topo-nodes 2 --config-nodes 2
+
+		# Create a cluster that has two 3-node raft partitions
+		onit create cluster --partitions 2 --partition-size 3
+
+		# Create a cluster that fetches docker images from a private docker registry
+		onit create cluster --docker-registry <host>:<port>
+	
+		# Create a cluster to deploy topo and config subsystems using the images with custom tags 
+        onit create cluster --image-tags topo=test-topo-tag,config=test-config-tag`
+)
+
+// getCreateCommand returns a cobra "setup" command for setting up resources
+func getCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create {cluster} [args]",
+		Short:   "Create a test resource on Kubernetes",
+		Example: createExample,
+	}
+	cmd.AddCommand(getCreateClusterCommand())
+	return cmd
+}
+
+// getCreateClusterCommand returns a cobra command for deploying a test cluster
+func getCreateClusterCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster [id]",
+		Short: "Setup a test cluster on Kubernetes",
+		Args:  cobra.MaximumNArgs(1),
+		RunE:  runCreateClusterCommand,
+	}
+
+	images := make(map[string]string)
+	images[atomixService] = defaultAtomixImage
+	images[raftService] = defaultRaftImage
+	images[configService] = defaultConfigImage
+	images[topoService] = defaultTopoImage
+
+	nodes := make(map[string]int)
+	nodes[atomixService] = 1
+	nodes[raftService] = 3
+	nodes[configService] = 1
+	nodes[topoService] = 1
+
+	cmd.Flags().StringToStringP("image", "i", images, "override the image to deploy for a subsystem")
+	cmd.Flags().StringToIntP("nodes", "n", nodes, "set the number of nodes to deploy for a subsystem")
+	cmd.Flags().IntP("partitions", "p", 1, "the number of Raft partitions to deploy")
+	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
+
+	return cmd
+}
+
+func runCreateClusterCommand(cmd *cobra.Command, args []string) error {
+	var clusterID string
+	if len(args) > 0 {
+		clusterID = args[0]
+	}
+	if clusterID == "" {
+		clusterID = random.NewPetName(2)
+	}
+
+	images, _ := cmd.Flags().GetStringToString("image")
+	nodes, _ := cmd.Flags().GetStringToInt("nodes")
+	partitions, _ := cmd.Flags().GetInt("partitions")
+	imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
+	pullPolicy := corev1.PullPolicy(imagePullPolicy)
+
+	client, err := k8s.GetClientset()
+	if err != nil {
+		return err
+	}
+
+	clusterSetup := &clusterSetup{
+		clusterID: clusterID,
+		client:    client,
+	}
+	if err := clusterSetup.setup(); err != nil {
+		return err
+	}
+
+	kubeAPI := kube.GetAPI(clusterID)
+	setup := setup.New(kubeAPI)
+	setup.Atomix().
+		Using().
+		Image(images[atomixService]).
+		PullPolicy(pullPolicy)
+	setup.Database().
+		Partitions(partitions).
+		Nodes(nodes[raftService]).
+		Using().
+		Image(images[raftService]).
+		PullPolicy(pullPolicy)
+	if nodes[configService] > 0 {
+		setup.Config().
+			Nodes(nodes[configService]).
+			Using().
+			Image(images[configService]).
+			PullPolicy(pullPolicy)
+	}
+	if nodes[topoService] > 0 {
+		setup.Topo().
+			Nodes(nodes[topoService]).
+			Using().
+			Image(images[topoService]).
+			PullPolicy(pullPolicy)
+	}
+	return setup.Setup()
+}

--- a/pkg/new/onit/cli/delete.go
+++ b/pkg/new/onit/cli/delete.go
@@ -1,0 +1,65 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/onosproject/onos-test/pkg/new/util/k8s"
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteExample = `
+		# Delete a cluster with a given name
+		onit delete cluster <name of cluster>
+
+		# Delete the currently configured cluster
+		onit delete cluster`
+)
+
+// getDeleteCommand returns a cobra "teardown" command for tearing down Kubernetes test resources
+func getDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete",
+		Short:   "Delete Kubernetes test resources",
+		Example: deleteExample,
+	}
+	cmd.AddCommand(getDeleteClusterCommand())
+	return cmd
+}
+
+// getDeleteClusterCommand returns a cobra "teardown" command for tearing down a test cluster
+func getDeleteClusterCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cluster <id>",
+		Short: "Delete a test cluster on Kubernetes",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runDeleteClusterCommand,
+	}
+	return cmd
+}
+
+func runDeleteClusterCommand(cmd *cobra.Command, args []string) error {
+	clusterID := args[0]
+	client, err := k8s.GetClientset()
+	if err != nil {
+		return err
+	}
+
+	clusterSetup := &clusterSetup{
+		clusterID: clusterID,
+		client:    client,
+	}
+	return clusterSetup.teardown()
+}

--- a/pkg/new/onit/cli/remove.go
+++ b/pkg/new/onit/cli/remove.go
@@ -58,9 +58,6 @@ func getRemoveNetworkCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the network")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	return cmd
 }
 
@@ -88,9 +85,6 @@ func getRemoveSimulatorCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the simulator")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	return cmd
 }
 
@@ -118,9 +112,6 @@ func getRemoveAppCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to remove the app")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	return cmd
 }
 

--- a/pkg/new/onit/cli/remove.go
+++ b/pkg/new/onit/cli/remove.go
@@ -1,0 +1,139 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"github.com/onosproject/onos-test/pkg/new/kube"
+	"github.com/onosproject/onos-test/pkg/new/onit/env"
+	"github.com/onosproject/onos-test/pkg/onit/setup"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	removeExample = `
+		# Remove a simulator with a given name
+		onit remove simulator <simulator-name>
+
+		# Remove a network with a given name
+		onit remove network <network-name>
+	
+		# Remove an app
+		onit remove app <app-name>`
+)
+
+// getRemoveCommand returns a cobra "remove" command for removing resources from the cluster
+func getRemoveCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove {simulator} [args]",
+		Short:   "Remove resources from the cluster",
+		Example: removeExample,
+	}
+	cmd.AddCommand(getRemoveSimulatorCommand())
+	cmd.AddCommand(getRemoveNetworkCommand())
+	cmd.AddCommand(getRemoveAppCommand())
+	return cmd
+}
+
+// getRemoveNetworkCommand returns a cobra command for tearing down a stratum network
+func getRemoveNetworkCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "network [name]",
+		Short: "Remove a stratum network from the cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runRemoveNetworkCommand,
+	}
+
+	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the network")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+}
+
+func runRemoveNetworkCommand(cmd *cobra.Command, args []string) error {
+	networkID := args[0]
+	cluster, _ := cmd.Flags().GetString("cluster")
+
+	kubeAPI := kube.GetAPI(cluster)
+	env := env.New(kubeAPI)
+	network := env.Simulator(networkID)
+	if network == nil {
+		return fmt.Errorf("unknown network: %s", networkID)
+	}
+	network.Remove()
+	return nil
+}
+
+// getRemoveSimulatorCommand returns a cobra command for tearing down a device simulator
+func getRemoveSimulatorCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "simulator <name>",
+		Short: "Remove a device simulator from the cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runRemoveSimulatorCommand,
+	}
+
+	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to add the simulator")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+}
+
+func runRemoveSimulatorCommand(cmd *cobra.Command, args []string) error {
+	deviceID := args[0]
+	cluster, _ := cmd.Flags().GetString("cluster")
+
+	kubeAPI := kube.GetAPI(cluster)
+	env := env.New(kubeAPI)
+	simulator := env.Simulator(deviceID)
+	if simulator == nil {
+		return fmt.Errorf("unknown device: %s", deviceID)
+	}
+	simulator.Remove()
+	return nil
+}
+
+// getRemoveAppCommand returns a cobra command for tearing down an app
+func getRemoveAppCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "app <name>",
+		Short: "Remove an app from the cluster",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runRemoveAppCommand,
+	}
+
+	cmd.Flags().StringP("cluster", "c", setup.GetDefaultCluster(), "the cluster to which to remove the app")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	return cmd
+}
+
+func runRemoveAppCommand(cmd *cobra.Command, args []string) error {
+	appID := args[0]
+	cluster, _ := cmd.Flags().GetString("cluster")
+
+	kubeAPI := kube.GetAPI(cluster)
+	env := env.New(kubeAPI)
+	app := env.App(appID)
+	if app == nil {
+		return fmt.Errorf("unknown application: %s", appID)
+	}
+	app.Remove()
+	return nil
+}

--- a/pkg/new/onit/cli/root.go
+++ b/pkg/new/onit/cli/root.go
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package setup
+package cli
 
-// AppSetup is an interface for setting up an application
-type AppSetup interface {
-	Setup
-	ServiceTypeSetup
+import "github.com/spf13/cobra"
 
-	// Nodes sets the number of application nodes
-	Nodes(nodes int) AppSetup
+// GetRootCommand returns the root onit command
+func GetRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "onit <command> [args]",
+		Short: "Setup test clusters and run integration tests on Kubernetes",
+	}
+	cmd.AddCommand(getCreateCommand())
+	cmd.AddCommand(getDeleteCommand())
+	cmd.AddCommand(getAddCommand())
+	cmd.AddCommand(getRemoveCommand())
+	cmd.AddCommand(getRunCommand())
+	return cmd
 }

--- a/pkg/new/onit/cli/run.go
+++ b/pkg/new/onit/cli/run.go
@@ -1,0 +1,142 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/onosproject/onos-test/pkg/new/kubetest"
+	"github.com/onosproject/onos-test/pkg/new/util/k8s"
+	"github.com/onosproject/onos-test/pkg/new/util/random"
+	corev1 "k8s.io/api/core/v1"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	runExample = `
+		# Run a single test on the cluster
+		onit run test <name of a test>
+
+		# Run a benchmark on the cluster
+		onit run bench <name of a benchmark>`
+)
+
+// getRunCommand returns a cobra run command to run integration tests
+func getRunCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "run {test,bench}",
+		Short:   "Run integration tests",
+		Example: runExample,
+	}
+	cmd.AddCommand(getRunTestCommand())
+	cmd.AddCommand(getRunBenchCommand())
+	return cmd
+}
+
+func getRunTestCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test [tests]",
+		Short: "Run tests on Kubernetes",
+		RunE:  runRunTestCommand,
+	}
+	cmd.Flags().StringP("cluster", "c", "", "the cluster on which to run the test")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	cmd.Flags().StringP("image", "i", "", "the test image to run")
+	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
+	cmd.Flags().StringP("suite", "s", "", "the test suite to run")
+	cmd.Flags().StringP("test", "t", "", "the name of the test method to run")
+	cmd.Flags().Duration("timeout", 10*time.Minute, "test timeout")
+	return cmd
+}
+
+// runRunTestCommand runs the run test command
+func runRunTestCommand(cmd *cobra.Command, _ []string) error {
+	return runTest(cmd, kubetest.TestTypeTest)
+}
+
+func getRunBenchCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test [tests]",
+		Short: "Run benchmarks on Kubernetes",
+		RunE:  runRunBenchCommand,
+	}
+	cmd.Flags().StringP("cluster", "c", "", "the cluster on which to run the test")
+	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
+		cobra.BashCompCustom: {"__onit_get_clusters"},
+	}
+	cmd.Flags().StringP("image", "i", "", "the test image to run")
+	cmd.Flags().StringP("suite", "s", "", "the test suite to run")
+	cmd.Flags().StringP("test", "t", "", "the name of the test method to run")
+	cmd.Flags().Duration("timeout", 10*time.Minute, "test timeout")
+	return cmd
+}
+
+// runRunBenchCommand runs the run test command
+func runRunBenchCommand(cmd *cobra.Command, _ []string) error {
+	return runTest(cmd, kubetest.TestTypeBenchmark)
+}
+
+func runTest(cmd *cobra.Command, testType kubetest.TestType) error {
+	clusterID, _ := cmd.Flags().GetString("cluster")
+	image, _ := cmd.Flags().GetString("image")
+	suite, _ := cmd.Flags().GetString("suite")
+	timeout, _ := cmd.Flags().GetDuration("timeout")
+	imagePullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
+	pullPolicy := corev1.PullPolicy(imagePullPolicy)
+
+	test := &kubetest.TestConfig{
+		TestID:     random.NewPetName(2),
+		Type:       testType,
+		Image:      image,
+		Suite:      suite,
+		Timeout:    timeout,
+		PullPolicy: pullPolicy,
+	}
+
+	// If the cluster ID was not specified, create a new cluster to run the test
+	// Otherwise, deploy the test in the existing cluster
+	if clusterID == "" {
+		runner, err := kubetest.NewTestRunner(test)
+		if err != nil {
+			return err
+		}
+		return runner.Run()
+	}
+
+	client, err := k8s.GetClientset()
+	if err != nil {
+		return err
+	}
+
+	clusterSetup := &clusterSetup{
+		clusterID: clusterID,
+		client:    client,
+	}
+	if err := clusterSetup.startTest(test); err != nil {
+		return err
+	}
+	if err := clusterSetup.awaitTestJobComplete(test); err != nil {
+		return err
+	}
+	_, code, err := clusterSetup.getStatus(test)
+	if err != nil {
+		return err
+	}
+	os.Exit(code)
+	return nil
+}

--- a/pkg/new/onit/cli/run.go
+++ b/pkg/new/onit/cli/run.go
@@ -53,9 +53,6 @@ func getRunTestCommand() *cobra.Command {
 		RunE:  runRunTestCommand,
 	}
 	cmd.Flags().StringP("cluster", "c", "", "the cluster on which to run the test")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	cmd.Flags().StringP("image", "i", "", "the test image to run")
 	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), "the Docker image pull policy")
 	cmd.Flags().StringP("suite", "s", "", "the test suite to run")
@@ -76,9 +73,6 @@ func getRunBenchCommand() *cobra.Command {
 		RunE:  runRunBenchCommand,
 	}
 	cmd.Flags().StringP("cluster", "c", "", "the cluster on which to run the test")
-	cmd.Flags().Lookup("cluster").Annotations = map[string][]string{
-		cobra.BashCompCustom: {"__onit_get_clusters"},
-	}
 	cmd.Flags().StringP("image", "i", "", "the test image to run")
 	cmd.Flags().StringP("suite", "s", "", "the test suite to run")
 	cmd.Flags().StringP("test", "t", "", "the name of the test method to run")

--- a/pkg/new/onit/cli/services.go
+++ b/pkg/new/onit/cli/services.go
@@ -12,13 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package setup
+package cli
 
-// AppSetup is an interface for setting up an application
-type AppSetup interface {
-	Setup
-	ServiceTypeSetup
+const (
+	atomixService = "atomix"
+	raftService   = "raft"
+	configService = "config"
+	topoService   = "topo"
+)
 
-	// Nodes sets the number of application nodes
-	Nodes(nodes int) AppSetup
-}
+const (
+	defaultAtomixImage    = "atomix/atomix-k8s-controller:latest"
+	defaultRaftImage      = "atomix/atomix-raft-node:latest"
+	defaultConfigImage    = "onosproject/onos-config:latest"
+	defaultTopoImage      = "onosproject/onos-topo:latest"
+	defaultMininetImage   = "opennetworkinglab/mininet:latest"
+	defaultSimulatorImage = "onosproject/simulators:latest"
+)

--- a/pkg/new/onit/env/app.go
+++ b/pkg/new/onit/env/app.go
@@ -18,6 +18,17 @@ import (
 	"github.com/onosproject/onos-test/pkg/new/onit/setup"
 )
 
+func newAppSetup(name string, testEnv *testEnv) setup.AppSetup {
+	setup := &appSetup{
+		serviceSetup: &serviceSetup{
+			testEnv: testEnv,
+		},
+		name: name,
+	}
+	setup.serviceSetup.setup = setup
+	return setup
+}
+
 // App provides the environment for an app
 type App interface {
 	Service
@@ -34,8 +45,18 @@ var _ setup.AppSetup = &appSetup{}
 
 // appSetup is an implementation of the AppSetup interface
 type appSetup struct {
-	*serviceTypeSetup
-	name string
+	*serviceSetup
+	name  string
+	nodes int
+}
+
+func (s *appSetup) Nodes(nodes int) setup.AppSetup {
+	s.nodes = nodes
+	return s
+}
+
+func (s *appSetup) Using() setup.ServiceSetup {
+	return s
 }
 
 func (s *appSetup) Setup() error {

--- a/pkg/new/onit/env/apps.go
+++ b/pkg/new/onit/env/apps.go
@@ -49,12 +49,5 @@ func (e *apps) Get(name string) App {
 }
 
 func (e *apps) Add(name string) setup.AppSetup {
-	return &appSetup{
-		serviceTypeSetup: &serviceTypeSetup{
-			serviceSetup: &serviceSetup{
-				testEnv: e.testEnv,
-			},
-		},
-		name: name,
-	}
+	return newAppSetup(name, e.testEnv)
 }

--- a/pkg/new/onit/env/env.go
+++ b/pkg/new/onit/env/env.go
@@ -16,13 +16,13 @@ package env
 
 import (
 	atomixcontroller "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
-	"github.com/onosproject/onos-test/pkg/new/kubetest"
+	"github.com/onosproject/onos-test/pkg/new/kube"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 )
 
 // New returns a new onit Env
-func New(kube kubetest.KubeAPI) Env {
+func New(kube kube.API) Env {
 	env := &testEnv{
 		namespace:        kube.Namespace(),
 		kubeClient:       kubernetes.NewForConfigOrDie(kube.Config()),

--- a/pkg/new/onit/env/network.go
+++ b/pkg/new/onit/env/network.go
@@ -18,6 +18,17 @@ import (
 	"github.com/onosproject/onos-test/pkg/new/onit/setup"
 )
 
+func newNetworkSetup(name string, testEnv *testEnv) setup.NetworkSetup {
+	setup := &networkSetup{
+		serviceSetup: &serviceSetup{
+			testEnv: testEnv,
+		},
+		name: name,
+	}
+	setup.serviceSetup.setup = setup
+	return setup
+}
+
 // Network provides the environment for a network node
 type Network interface {
 	Service
@@ -34,8 +45,12 @@ var _ setup.NetworkSetup = &networkSetup{}
 
 // networkSetup is an implementation of the NetworkSetup interface
 type networkSetup struct {
-	*serviceTypeSetup
+	*serviceSetup
 	name string
+}
+
+func (s *networkSetup) Using() setup.ServiceSetup {
+	return s
 }
 
 func (s *networkSetup) Setup() error {

--- a/pkg/new/onit/env/networks.go
+++ b/pkg/new/onit/env/networks.go
@@ -49,12 +49,5 @@ func (e *networks) Get(name string) Network {
 }
 
 func (e *networks) Add(name string) setup.NetworkSetup {
-	return &networkSetup{
-		serviceTypeSetup: &serviceTypeSetup{
-			serviceSetup: &serviceSetup{
-				testEnv: e.testEnv,
-			},
-		},
-		name: name,
-	}
+	return newNetworkSetup(name, e.testEnv)
 }

--- a/pkg/new/onit/env/service.go
+++ b/pkg/new/onit/env/service.go
@@ -34,6 +34,12 @@ type Service interface {
 	Remove()
 }
 
+// ServiceSetup is a base interface for services that can be set up
+type ServiceSetup interface {
+	Service
+	setup.Setup
+}
+
 var _ Service = &service{}
 
 // service is an implementation of the Service interface
@@ -61,22 +67,12 @@ func (e *service) Remove() {
 	panic("implement me")
 }
 
-var _ setup.ServiceTypeSetup = &serviceTypeSetup{}
-
-// serviceTypeSetup is an implementation of the ServiceTypeSetup interface
-type serviceTypeSetup struct {
-	*serviceSetup
-}
-
-func (s *serviceTypeSetup) Using() setup.ServiceSetup {
-	return s.serviceSetup
-}
-
 var _ setup.ServiceSetup = &serviceSetup{}
 
 // serviceSetup is an implementation of the ServiceSetup interface
 type serviceSetup struct {
 	*testEnv
+	setup      setup.Setup
 	image      string
 	pullPolicy corev1.PullPolicy
 }
@@ -89,4 +85,8 @@ func (s *serviceSetup) Image(image string) setup.ServiceSetup {
 func (s *serviceSetup) PullPolicy(pullPolicy corev1.PullPolicy) setup.ServiceSetup {
 	s.pullPolicy = pullPolicy
 	return s
+}
+
+func (s *serviceSetup) Setup() error {
+	return s.setup.Setup()
 }

--- a/pkg/new/onit/env/simulator.go
+++ b/pkg/new/onit/env/simulator.go
@@ -18,6 +18,17 @@ import (
 	"github.com/onosproject/onos-test/pkg/new/onit/setup"
 )
 
+func newSimulatorSetup(name string, testEnv *testEnv) setup.SimulatorSetup {
+	setup := &simulatorSetup{
+		serviceSetup: &serviceSetup{
+			testEnv: testEnv,
+		},
+		name: name,
+	}
+	setup.serviceSetup.setup = setup
+	return setup
+}
+
 // Simulator provides the environment for a single simulator
 type Simulator interface {
 	Service
@@ -34,8 +45,12 @@ var _ setup.SimulatorSetup = &simulatorSetup{}
 
 // simulatorSetup is an implementation of the SimulatorSetup interface
 type simulatorSetup struct {
-	*serviceTypeSetup
+	*serviceSetup
 	name string
+}
+
+func (s *simulatorSetup) Using() setup.ServiceSetup {
+	return s
 }
 
 func (s *simulatorSetup) Setup() error {

--- a/pkg/new/onit/env/simulators.go
+++ b/pkg/new/onit/env/simulators.go
@@ -48,12 +48,5 @@ func (e *simulators) Get(name string) Simulator {
 }
 
 func (e *simulators) Add(name string) setup.SimulatorSetup {
-	return &simulatorSetup{
-		name: name,
-		serviceTypeSetup: &serviceTypeSetup{
-			serviceSetup: &serviceSetup{
-				testEnv: e.testEnv,
-			},
-		},
-	}
+	return newSimulatorSetup(name, e.testEnv)
 }

--- a/pkg/new/onit/setup/service.go
+++ b/pkg/new/onit/setup/service.go
@@ -39,6 +39,8 @@ type Service interface {
 
 // ServiceSetup provides methods for setting up a service
 type ServiceSetup interface {
+	Setup
+
 	// Image sets the simulator image to deploy
 	Image(image string) ServiceSetup
 

--- a/pkg/new/onit/setup/setup.go
+++ b/pkg/new/onit/setup/setup.go
@@ -16,13 +16,13 @@ package setup
 
 import (
 	atomixcontroller "github.com/atomix/atomix-k8s-controller/pkg/client/clientset/versioned"
-	"github.com/onosproject/onos-test/pkg/new/kubetest"
+	"github.com/onosproject/onos-test/pkg/new/kube"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 )
 
 // New returns a new onit Setup
-func New(kube kubetest.KubeAPI) TestSetup {
+func New(kube kube.API) TestSetup {
 	setup := &testSetup{
 		namespace:        kube.Namespace(),
 		kubeClient:       kubernetes.NewForConfigOrDie(kube.Config()),

--- a/pkg/new/onit/test.go
+++ b/pkg/new/onit/test.go
@@ -42,6 +42,6 @@ type SetupONOSTestSuite interface {
 // setupONOSTest sets up the ONOS cluster for the given benchmark suite
 func setupONOSTest(t TestSuite) {
 	if setupONOS, ok := t.(SetupONOSTestSuite); ok {
-		setupONOS.SetupONOSTestSuite(setup.New(t.KubeAPI()))
+		setupONOS.SetupONOSTestSuite(setup.New(t.API()))
 	}
 }

--- a/pkg/new/util/random/petname.go
+++ b/pkg/new/util/random/petname.go
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package setup
+package random
 
-// AppSetup is an interface for setting up an application
-type AppSetup interface {
-	Setup
-	ServiceTypeSetup
+import "github.com/dustinkirkland/golang-petname"
 
-	// Nodes sets the number of application nodes
-	Nodes(nodes int) AppSetup
+// NewPetName returns a new random pet name
+func NewPetName(words int) string {
+	return petname.Generate(words, "-")
 }


### PR DESCRIPTION
This PR adds a new implementation of the `onit` CLI. The command is named `onit-new` until all the setup functionality has been migrated and we're confident the commands are stable. Note that the full implementation does not yet work. The setup/env implementations are incomplete still... to be completed in the next PR.