### PR TITLE
Update to use same set of linters as onos-config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,10 @@ linters:
     - misspell
     - typecheck
     - errcheck
+    - dogsled
+    - unconvert
+    - nakedret
+    - scopelint
 issues:
   exclude-use-default: false
   exclude:

--- a/pkg/onit/k8s/image.go
+++ b/pkg/onit/k8s/image.go
@@ -198,7 +198,7 @@ func (c *ClusterController) updateDeployment(name string, image string, pullPoli
 			return err
 		}
 		deployment.Spec.Template.Spec.Containers[0].Image = image
-		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = corev1.PullPolicy(pullPolicy)
+		deployment.Spec.Template.Spec.Containers[0].ImagePullPolicy = pullPolicy
 
 		if strings.Compare(deployment.Spec.Template.Spec.Containers[0].Image, image) == 0 {
 			deployment.Spec.Template.CreationTimestamp = metav1.Now()

--- a/test/config/opstate-cli.go
+++ b/test/config/opstate-cli.go
@@ -106,11 +106,12 @@ func TestConfigGetCLI(t *testing.T) {
 
 	// Run the test cases
 	for _, testCase := range testCases {
-		description := makeDescription(testCase.path)
+		thisTestCase := testCase
+		description := makeDescription(thisTestCase.path)
 		t.Run(description,
 			func(t *testing.T) {
-				path := testCase.path
-				expectedValue := testCase.expectedValue
+				path := thisTestCase.path
+				expectedValue := thisTestCase.expectedValue
 				t.Parallel()
 				assert.Equal(t, expectedValue, opState[path])
 			})

--- a/test/integration/modelstest.go
+++ b/test/integration/modelstest.go
@@ -61,13 +61,14 @@ func TestModels(t *testing.T) {
 
 	// Run the test cases
 	for _, testCase := range testCases {
-		t.Run(testCase.description,
+		thisTestCase := testCase
+		t.Run(thisTestCase.description,
 			func(t *testing.T) {
-				description := testCase.description
-				path := testCase.path
-				value := testCase.value
-				valueType := testCase.valueType
-				expectedError := testCase.expectedError
+				description := thisTestCase.description
+				path := thisTestCase.path
+				value := thisTestCase.value
+				valueType := thisTestCase.valueType
+				expectedError := thisTestCase.expectedError
 				t.Parallel()
 
 				t.Logf("testing %q", description)


### PR DESCRIPTION
Adding dogsled, unconvert, nakedret, and scopelint linters.