### PR TITLE
Fix bugs in create cluster command

### DIFF
--- a/pkg/onit/cli/create.go
+++ b/pkg/onit/cli/create.go
@@ -75,6 +75,9 @@ func runCreateClusterCommand(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 	setup := setup.New(kubeAPI)
+	setup.Atomix()
 	setup.Partitions().Raft()
+	setup.Topo().SetReplicas(1)
+	setup.Config().SetReplicas(1)
 	return setup.Setup()
 }

--- a/pkg/onit/cluster/service.go
+++ b/pkg/onit/cluster/service.go
@@ -440,7 +440,7 @@ func (s *Service) createDeployment() error {
 
 // AwaitReady waits for the service to complete startup
 func (s *Service) AwaitReady() error {
-	if s.replicas == 0 {
+	if s.Replicas() == 0 {
 		return nil
 	}
 

--- a/pkg/onit/cluster/service.go
+++ b/pkg/onit/cluster/service.go
@@ -182,7 +182,7 @@ func (s *Service) SetArgs(args ...string) {
 
 // Setup sets up the service
 func (s *Service) Setup() error {
-	if s.replicas == 0 {
+	if s.Replicas() == 0 {
 		return nil
 	}
 
@@ -340,9 +340,8 @@ func (s *Service) createDeployment() error {
 
 		volumeMounts = make([]corev1.VolumeMount, 0, len(s.secrets))
 		for filepath := range s.secrets {
-			filename := path.Dir(filepath)
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
-				Name:      filename,
+				Name:      "secret",
 				MountPath: filepath,
 				SubPath:   getKey(filepath),
 				ReadOnly:  true,


### PR DESCRIPTION
This PR fixes various bugs in the `onit create cluster` command:
* Ensure the `Service` base respects `replica` setting overrides when default number of replicas is `0`
* Set the default number of replicas to `1` for both `onos-topo` and `onos-config`
* Secret mounts are fixed