### PR TITLE
Add onos-gui, envoy setup interface

### DIFF
--- a/pkg/cluster/runner.go
+++ b/pkg/cluster/runner.go
@@ -17,6 +17,9 @@ package cluster
 import (
 	"bufio"
 	"errors"
+	"os"
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/kube"
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	batchv1 "k8s.io/api/batch/v1"
@@ -25,8 +28,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"os"
-	"time"
 )
 
 const namespace = "kube-test"
@@ -221,6 +222,18 @@ func (r *Runner) createClusterRole() error {
 				Resources: []string{
 					"clusterroles",
 					"clusterrolebindings",
+				},
+				Verbs: []string{
+					"*",
+				},
+			},
+			{
+				APIGroups: []string{
+					"networking.k8s.io",
+					"extensions",
+				},
+				Resources: []string{
+					"ingresses",
 				},
 				Verbs: []string{
 					"*",

--- a/pkg/onit/cluster/app.go
+++ b/pkg/onit/cluster/app.go
@@ -29,7 +29,7 @@ func newApp(cluster *Cluster, name string) *App {
 	labels := getLabels(appType)
 	labels[appLabel] = name
 	return &App{
-		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}, nil),
+		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}, nil, nil),
 	}
 }
 

--- a/pkg/onit/cluster/app.go
+++ b/pkg/onit/cluster/app.go
@@ -29,7 +29,7 @@ func newApp(cluster *Cluster, name string) *App {
 	labels := getLabels(appType)
 	labels[appLabel] = name
 	return &App{
-		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}),
+		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}, nil),
 	}
 }
 

--- a/pkg/onit/cluster/app.go
+++ b/pkg/onit/cluster/app.go
@@ -29,7 +29,7 @@ func newApp(cluster *Cluster, name string) *App {
 	labels := getLabels(appType)
 	labels[appLabel] = name
 	return &App{
-		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}, nil, nil),
+		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}, nil, nil, nil),
 	}
 }
 

--- a/pkg/onit/cluster/app.go
+++ b/pkg/onit/cluster/app.go
@@ -29,7 +29,7 @@ func newApp(cluster *Cluster, name string) *App {
 	labels := getLabels(appType)
 	labels[appLabel] = name
 	return &App{
-		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}, nil, nil, nil),
+		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}),
 	}
 }
 

--- a/pkg/onit/cluster/cluster.go
+++ b/pkg/onit/cluster/cluster.go
@@ -38,6 +38,7 @@ func New(kube kube.API) *Cluster {
 	cluster.cli = newCLI(cluster)
 	cluster.topo = newTopo(cluster)
 	cluster.config = newConfig(cluster)
+	cluster.gui = newGui(cluster)
 	cluster.apps = newApps(cluster)
 	cluster.simulators = newSimulators(cluster)
 	cluster.networks = newNetworks(cluster)
@@ -52,6 +53,7 @@ type Cluster struct {
 	cli        *CLI
 	topo       *Topo
 	config     *Config
+	gui        *Gui
 	apps       *Apps
 	simulators *Simulators
 	networks   *Networks
@@ -80,6 +82,11 @@ func (c *Cluster) Topo() *Topo {
 // Config returns the configuration service
 func (c *Cluster) Config() *Config {
 	return c.config
+}
+
+// Gui returns the gui service
+func (c *Cluster) Gui() *Gui {
+	return c.gui
 }
 
 // Apps returns the cluster applications

--- a/pkg/onit/cluster/cluster.go
+++ b/pkg/onit/cluster/cluster.go
@@ -40,6 +40,7 @@ func New(kube kube.API) *Cluster {
 	cluster.config = newConfig(cluster)
 	cluster.gui = newGui(cluster)
 	cluster.apps = newApps(cluster)
+	cluster.envoy = newEnvoy(cluster)
 	cluster.simulators = newSimulators(cluster)
 	cluster.networks = newNetworks(cluster)
 	return cluster
@@ -54,6 +55,7 @@ type Cluster struct {
 	topo       *Topo
 	config     *Config
 	gui        *Gui
+	envoy      *Envoy
 	apps       *Apps
 	simulators *Simulators
 	networks   *Networks
@@ -87,6 +89,11 @@ func (c *Cluster) Config() *Config {
 // Gui returns the gui service
 func (c *Cluster) Gui() *Gui {
 	return c.gui
+}
+
+// Envoy returns the cluster envoy proxy
+func (c *Cluster) Envoy() *Envoy {
+	return c.envoy
 }
 
 // Apps returns the cluster applications

--- a/pkg/onit/cluster/config.go
+++ b/pkg/onit/cluster/config.go
@@ -38,9 +38,10 @@ var configArgs = []string{
 }
 
 func newConfig(cluster *Cluster) *Config {
-	return &Config{
+	config := &Config{
 		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs),
 	}
+	return config
 }
 
 // Config provides methods for managing the onos-config service

--- a/pkg/onit/cluster/config.go
+++ b/pkg/onit/cluster/config.go
@@ -39,7 +39,7 @@ var configArgs = []string{
 
 func newConfig(cluster *Cluster) *Config {
 	return &Config{
-		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs),
+		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs, nil),
 	}
 }
 

--- a/pkg/onit/cluster/config.go
+++ b/pkg/onit/cluster/config.go
@@ -39,7 +39,7 @@ var configArgs = []string{
 
 func newConfig(cluster *Cluster) *Config {
 	return &Config{
-		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs, nil, nil),
+		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs, nil, nil, nil),
 	}
 }
 

--- a/pkg/onit/cluster/config.go
+++ b/pkg/onit/cluster/config.go
@@ -39,7 +39,7 @@ var configArgs = []string{
 
 func newConfig(cluster *Cluster) *Config {
 	return &Config{
-		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs, nil),
+		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs, nil, nil),
 	}
 }
 

--- a/pkg/onit/cluster/config.go
+++ b/pkg/onit/cluster/config.go
@@ -39,7 +39,7 @@ var configArgs = []string{
 
 func newConfig(cluster *Cluster) *Config {
 	return &Config{
-		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs, nil, nil, nil),
+		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs),
 	}
 }
 

--- a/pkg/onit/cluster/envoy.go
+++ b/pkg/onit/cluster/envoy.go
@@ -100,9 +100,8 @@ func newEnvoy(cluster *Cluster) *Envoy {
 	var envoyConfigMaps = map[string]string{
 		"/etc/envoy-proxy/config/envoy-config.yaml": envoyConfig,
 	}
-
 	return &Envoy{
-		Service: newService(cluster, envoyService, []Port{{Name: "envoy", Port: envoyPort}}, getLabels(envoyType), envoyImage, envoySecrets, nil, envoyCommand, envoyConfigMaps),
+		Service: newService(cluster, envoyService, []Port{{Name: "envoy", Port: envoyPort}}, getLabels(envoyType), envoyImage, envoySecrets, nil, envoyCommand, envoyConfigMaps, nil),
 	}
 }
 

--- a/pkg/onit/cluster/envoy.go
+++ b/pkg/onit/cluster/envoy.go
@@ -1,0 +1,110 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+const (
+	envoyType    = "envoy"
+	envoyService = "onos-envoy"
+	envoyImage   = "envoyproxy/envoy-alpine:latest"
+	envoyPort    = 8080
+)
+
+const envoyConfig = `admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 8080 }
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: onos_config_service
+                            max_grpc_timeout: 0s
+                      cors:
+                        allow_origin:
+                          - "*"
+                        allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        max_age: "1728000"
+                        expose_headers: custom-header-1,grpc-status,grpc-message
+                http_filters:
+                  - name: envoy.grpc_web
+                  - name: envoy.cors
+                  - name: envoy.router
+  clusters:
+    - name: onos_config_service
+      connect_timeout: 0.25s
+      type: logical_dns
+      http2_protocol_options: {}
+      lb_policy: round_robin
+      # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
+      hosts: [{ socket_address: { address: onos-topo, port_value: 5150 }}]
+      tls_context:
+        common_tls_context:
+          tls_certificates:
+            certificate_chain: { "filename": "/etc/envoy-proxy/certs/client1.crt" }
+            private_key: { "filename": "/etc/envoy-proxy/certs/client1.key" }
+          validation_context:
+            trusted_ca: { filename: "/etc/envoy-proxy/certs/onf.cacrt" }`
+
+var envoyCommand = []string{
+	"/usr/local/bin/envoy",
+	"-c",
+	"/etc/envoy-proxy/config/envoy-config.yaml",
+}
+
+var envoySecrets = map[string]string{
+	"/etc/envoy-proxy/config/envoy-config.yml": envoyConfig,
+	"/etc/envoy-proxy/certs/onf.cacrt":         caCert,
+	"/etc/envoy-proxy/certs/client1.crt":       clientCert,
+	"/etc/envoy-proxy/certs/client.key":        clientKey,
+}
+
+// Enabled indicates whether the Gui is enabled
+func (c *Envoy) Enabled() bool {
+	return GetArg(c.name, "enabled").Bool(c.enabled)
+}
+
+// SetEnabled sets whether the Envoy is enabled
+func (c *Envoy) SetEnabled(enabled bool) {
+	c.enabled = enabled
+}
+
+func newEnvoy(cluster *Cluster) *Envoy {
+	return &Envoy{
+		Service: newService(cluster, envoyService, []Port{{Name: "envoy", Port: envoyPort}}, getLabels(envoyType), envoyImage, envoySecrets, nil, envoyCommand),
+	}
+}
+
+// Envoy provides methods for managing the envoy service
+type Envoy struct {
+	*Service
+	enabled bool
+}

--- a/pkg/onit/cluster/envoy.go
+++ b/pkg/onit/cluster/envoy.go
@@ -27,66 +27,10 @@ var envoyCommand = []string{
 	"/etc/envoy-proxy/config/envoy-config.yaml",
 }
 
-const envoyConfig = `
-admin:
-  access_log_path: /tmp/admin_access.log
-  address:
-    socket_address: { address: 0.0.0.0, port_value: 9901 }
-static_resources:
-  listeners:
-    - name: listener_0
-      address:
-        socket_address: { address: 0.0.0.0, port_value: 8080 }
-      filter_chains:
-        - filters:
-            - name: envoy.http_connection_manager
-              config:
-                codec_type: auto
-                stat_prefix: ingress_http
-                route_config:
-                  name: local_route
-                  virtual_hosts:
-                    - name: local_service
-                      domains: ["*"]
-                      routes:
-                        - match: { prefix: "/" }
-                          route:
-                            cluster: onos_config_service
-                            max_grpc_timeout: 0s
-                      cors:
-                        allow_origin:
-                          - "*"
-                        allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
-                        max_age: "1728000"
-                        expose_headers: custom-header-1,grpc-status,grpc-message
-                http_filters:
-                  - name: envoy.grpc_web
-                  - name: envoy.cors
-                  - name: envoy.router
-  clusters:
-    - name: onos_config_service
-      connect_timeout: 0.25s
-      type: logical_dns
-      http2_protocol_options: {}
-      lb_policy: round_robin
-      # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
-      hosts: [{ socket_address: { address: onos-topo, port_value: 5150 }}]
-      tls_context:
-        common_tls_context:
-          tls_certificates:
-            certificate_chain: { "filename": "/certs/client.crt" }
-            private_key: { "filename": "/certs/client.key" }
-          validation_context:
-            trusted_ca: { filename: "/certs/onf.cacrt" }`
-
 var envoySecrets = map[string]string{
 	"/certs/onf.cacrt":  caCert,
 	"/certs/client.crt": clientCert,
 	"/certs/client.key": clientKey,
-}
-var envoyConfigMaps = map[string]string{
-	"/etc/envoy-proxy/config/envoy-config.yaml": envoyConfig,
 }
 
 // Enabled indicates whether the Gui is enabled
@@ -101,7 +45,6 @@ func (c *Envoy) SetEnabled(enabled bool) {
 
 func newEnvoy(cluster *Cluster) *Envoy {
 	service := newService(cluster, envoyService, []Port{{Name: "envoy", Port: envoyPort}}, getLabels(envoyType), envoyImage, envoySecrets, nil)
-	service.SetConfigMaps(envoyConfigMaps)
 	service.SetCommand(envoyCommand...)
 	return &Envoy{
 		Service: service,

--- a/pkg/onit/cluster/envoy.go
+++ b/pkg/onit/cluster/envoy.go
@@ -85,6 +85,9 @@ var envoySecrets = map[string]string{
 	"/certs/client.crt": clientCert,
 	"/certs/client.key": clientKey,
 }
+var envoyConfigMaps = map[string]string{
+	"/etc/envoy-proxy/config/envoy-config.yaml": envoyConfig,
+}
 
 // Enabled indicates whether the Gui is enabled
 func (c *Envoy) Enabled() bool {
@@ -97,11 +100,11 @@ func (c *Envoy) SetEnabled(enabled bool) {
 }
 
 func newEnvoy(cluster *Cluster) *Envoy {
-	var envoyConfigMaps = map[string]string{
-		"/etc/envoy-proxy/config/envoy-config.yaml": envoyConfig,
-	}
+	service := newService(cluster, envoyService, []Port{{Name: "envoy", Port: envoyPort}}, getLabels(envoyType), envoyImage, envoySecrets, nil)
+	service.SetConfigMaps(envoyConfigMaps)
+	service.SetCommand(envoyCommand...)
 	return &Envoy{
-		Service: newService(cluster, envoyService, []Port{{Name: "envoy", Port: envoyPort}}, getLabels(envoyType), envoyImage, envoySecrets, nil, envoyCommand, envoyConfigMaps, nil),
+		Service: service,
 	}
 }
 

--- a/pkg/onit/cluster/gui.go
+++ b/pkg/onit/cluster/gui.go
@@ -1,0 +1,44 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+const (
+	guiType    = "gui"
+	guiImage   = "onosproject/onos-gui:latest"
+	guiService = "onos-gui"
+	guiPort    = 80
+)
+
+// Enabled indicates whether the CLI is enabled
+func (c *Gui) Enabled() bool {
+	return GetArg(c.name, "enabled").Bool(c.enabled)
+}
+
+// SetEnabled sets whether the CLI is enabled
+func (c *Gui) SetEnabled(enabled bool) {
+	c.enabled = enabled
+}
+
+func newGui(cluster *Cluster) *Gui {
+	return &Gui{
+		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil),
+	}
+}
+
+// Gui provides methods for managing the onos-gui service
+type Gui struct {
+	*Service
+	enabled bool
+}

--- a/pkg/onit/cluster/gui.go
+++ b/pkg/onit/cluster/gui.go
@@ -21,6 +21,10 @@ const (
 	guiPort    = 80
 )
 
+var ingressAnnotations = map[string]string{
+	"kubernetes.io/ingress.class": "nginx",
+}
+
 // Enabled indicates whether the Gui is enabled
 func (c *Gui) Enabled() bool {
 	return GetArg(c.name, "enabled").Bool(c.enabled)
@@ -33,7 +37,7 @@ func (c *Gui) SetEnabled(enabled bool) {
 
 func newGui(cluster *Cluster) *Gui {
 	return &Gui{
-		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil, nil, nil),
+		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil, nil, nil, ingressAnnotations),
 	}
 }
 

--- a/pkg/onit/cluster/gui.go
+++ b/pkg/onit/cluster/gui.go
@@ -21,19 +21,19 @@ const (
 	guiPort    = 80
 )
 
-// Enabled indicates whether the CLI is enabled
+// Enabled indicates whether the Gui is enabled
 func (c *Gui) Enabled() bool {
 	return GetArg(c.name, "enabled").Bool(c.enabled)
 }
 
-// SetEnabled sets whether the CLI is enabled
+// SetEnabled sets whether the Gui is enabled
 func (c *Gui) SetEnabled(enabled bool) {
 	c.enabled = enabled
 }
 
 func newGui(cluster *Cluster) *Gui {
 	return &Gui{
-		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil),
+		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil, nil),
 	}
 }
 

--- a/pkg/onit/cluster/gui.go
+++ b/pkg/onit/cluster/gui.go
@@ -14,6 +14,63 @@
 
 package cluster
 
+const envoyConfig = `
+admin:
+  access_log_path: /tmp/admin_access.log
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 8080 }
+      filter_chains:
+        - filters:
+            - name: envoy.http_connection_manager
+              config:
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: onos_config_service
+                            max_grpc_timeout: 0s
+                      cors:
+                        allow_origin:
+                          - "*"
+                        allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        max_age: "1728000"
+                        expose_headers: custom-header-1,grpc-status,grpc-message
+                http_filters:
+                  - name: envoy.grpc_web
+                  - name: envoy.cors
+                  - name: envoy.router
+  clusters:
+    - name: onos_config_service
+      connect_timeout: 0.25s
+      type: logical_dns
+      http2_protocol_options: {}
+      lb_policy: round_robin
+      # win/mac hosts: Use address: host.docker.internal instead of address: localhost in the line below
+      hosts: [{ socket_address: { address: onos-topo, port_value: 5150 }}]
+      tls_context:
+        common_tls_context:
+          tls_certificates:
+            certificate_chain: { "filename": "/certs/client.crt" }
+            private_key: { "filename": "/certs/client.key" }
+          validation_context:
+            trusted_ca: { filename: "/certs/onf.cacrt" }`
+
+var envoyConfigMaps = map[string]string{
+	"/etc/envoy-proxy/config/envoy-config.yaml": envoyConfig,
+}
+
 const (
 	guiType    = "gui"
 	guiImage   = "onosproject/onos-gui:latest"
@@ -42,7 +99,9 @@ func newGui(cluster *Cluster) *Gui {
 	onosConfigEnvoy.SetName("onos-config-envoy")
 	onosConfigEnvoy.SetReplicas(1)
 	onosConfigEnvoy.SetEnabled(true)
+	onosConfigEnvoy.SetConfigMaps(envoyConfigMaps)
 	onosTopoEnvoy := newEnvoy(cluster)
+	onosTopoEnvoy.SetConfigMaps(envoyConfigMaps)
 	onosTopoEnvoy.SetName("onos-topo-envoy")
 	onosTopoEnvoy.SetReplicas(1)
 	onosTopoEnvoy.SetEnabled(true)

--- a/pkg/onit/cluster/gui.go
+++ b/pkg/onit/cluster/gui.go
@@ -38,8 +38,19 @@ func (c *Gui) SetEnabled(enabled bool) {
 func newGui(cluster *Cluster) *Gui {
 	service := newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil)
 	service.SetAnnotations(ingressAnnotations)
+	onosConfigEnvoy := newEnvoy(cluster)
+	onosConfigEnvoy.SetName("onos-config-envoy")
+	onosConfigEnvoy.SetReplicas(1)
+	onosConfigEnvoy.SetEnabled(true)
+	onosTopoEnvoy := newEnvoy(cluster)
+	onosTopoEnvoy.SetName("onos-topo-envoy")
+	onosTopoEnvoy.SetReplicas(1)
+	onosTopoEnvoy.SetEnabled(true)
+
 	return &Gui{
-		Service: service,
+		Service:    service,
+		OnosTopo:   onosTopoEnvoy,
+		OnosConfig: onosConfigEnvoy,
 	}
 
 }
@@ -47,5 +58,7 @@ func newGui(cluster *Cluster) *Gui {
 // Gui provides methods for managing the onos-gui service
 type Gui struct {
 	*Service
-	enabled bool
+	OnosTopo   *Envoy
+	OnosConfig *Envoy
+	enabled    bool
 }

--- a/pkg/onit/cluster/gui.go
+++ b/pkg/onit/cluster/gui.go
@@ -36,9 +36,12 @@ func (c *Gui) SetEnabled(enabled bool) {
 }
 
 func newGui(cluster *Cluster) *Gui {
+	service := newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil)
+	service.SetAnnotations(ingressAnnotations)
 	return &Gui{
-		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil, nil, nil, ingressAnnotations),
+		Service: service,
 	}
+
 }
 
 // Gui provides methods for managing the onos-gui service

--- a/pkg/onit/cluster/gui.go
+++ b/pkg/onit/cluster/gui.go
@@ -33,7 +33,7 @@ func (c *Gui) SetEnabled(enabled bool) {
 
 func newGui(cluster *Cluster) *Gui {
 	return &Gui{
-		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil, nil),
+		Service: newService(cluster, guiService, []Port{{Name: "grpc", Port: guiPort}}, getLabels(guiType), guiImage, nil, nil, nil, nil),
 	}
 }
 

--- a/pkg/onit/cluster/service.go
+++ b/pkg/onit/cluster/service.go
@@ -372,8 +372,11 @@ func (s *Service) createIngress() error {
 	}
 
 	// TODO it should be replaced with a more generic function
-	err := s.createGuiIngress()
-	return err
+	if s.Name() == "onos-gui" {
+		err := s.createGuiIngress()
+		return err
+	}
+	return nil
 
 }
 

--- a/pkg/onit/cluster/service.go
+++ b/pkg/onit/cluster/service.go
@@ -31,22 +31,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func newService(cluster *Cluster, name string,
-	ports []Port,
-	labels map[string]string, image string,
-	secrets map[string]string, args []string,
-	command []string,
-	configMaps map[string]string,
-	annotations map[string]string) *Service {
+func newService(cluster *Cluster, name string, ports []Port, labels map[string]string, image string, secrets map[string]string, args []string) *Service {
 	return &Service{
-		Deployment:  newDeployment(cluster, name, labels, image),
-		ports:       ports,
-		secrets:     secrets,
-		env:         make(map[string]string),
-		command:     command,
-		args:        args,
-		configMaps:  configMaps,
-		annotations: annotations,
+		Deployment: newDeployment(cluster, name, labels, image),
+		ports:      ports,
+		secrets:    secrets,
+		env:        make(map[string]string),
+		args:       args,
 	}
 }
 

--- a/pkg/onit/cluster/topo.go
+++ b/pkg/onit/cluster/topo.go
@@ -40,7 +40,7 @@ var topoArgs = []string{
 
 func newTopo(cluster *Cluster) *Topo {
 	return &Topo{
-		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs, nil, nil),
+		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs, nil, nil, nil),
 	}
 }
 

--- a/pkg/onit/cluster/topo.go
+++ b/pkg/onit/cluster/topo.go
@@ -40,7 +40,7 @@ var topoArgs = []string{
 
 func newTopo(cluster *Cluster) *Topo {
 	return &Topo{
-		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs, nil, nil, nil),
+		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs),
 	}
 }
 

--- a/pkg/onit/cluster/topo.go
+++ b/pkg/onit/cluster/topo.go
@@ -40,7 +40,7 @@ var topoArgs = []string{
 
 func newTopo(cluster *Cluster) *Topo {
 	return &Topo{
-		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs),
+		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs, nil),
 	}
 }
 

--- a/pkg/onit/cluster/topo.go
+++ b/pkg/onit/cluster/topo.go
@@ -39,9 +39,10 @@ var topoArgs = []string{
 }
 
 func newTopo(cluster *Cluster) *Topo {
-	return &Topo{
+	topo := &Topo{
 		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs),
 	}
+	return topo
 }
 
 // Topo provides methods for managing the onos-topo service

--- a/pkg/onit/cluster/topo.go
+++ b/pkg/onit/cluster/topo.go
@@ -40,7 +40,7 @@ var topoArgs = []string{
 
 func newTopo(cluster *Cluster) *Topo {
 	return &Topo{
-		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs, nil),
+		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs, nil, nil),
 	}
 }
 

--- a/pkg/onit/setup/envoy.go
+++ b/pkg/onit/setup/envoy.go
@@ -1,0 +1,70 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"github.com/onosproject/onos-test/pkg/onit/cluster"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EnvoySetup is an interface for setting up envoy nodes
+type EnvoySetup interface {
+
+	// SetEnabled enables the Envoy
+	SetEnabled() EnvoySetup
+
+	// SetReplicas sets the number of envoy replicas to deploy
+	SetReplicas(replicas int) EnvoySetup
+
+	// SetImage sets the envoy image to deploy
+	SetImage(image string) EnvoySetup
+
+	// SetPullPolicy sets the image pull policy
+	SetPullPolicy(pullPolicy corev1.PullPolicy) EnvoySetup
+}
+
+var _ EnvoySetup = &clusterEnvoySetup{}
+
+// clusterGuiSetup is an implementation of the Gui interface
+type clusterEnvoySetup struct {
+	envoy *cluster.Envoy
+}
+
+func (s *clusterEnvoySetup) SetEnabled() EnvoySetup {
+	s.envoy.SetEnabled(true)
+	return s
+}
+
+func (s *clusterEnvoySetup) SetReplicas(replicas int) EnvoySetup {
+	s.envoy.SetReplicas(replicas)
+	return s
+}
+
+func (s *clusterEnvoySetup) SetImage(image string) EnvoySetup {
+	s.envoy.SetImage(image)
+	return s
+}
+
+func (s *clusterEnvoySetup) SetPullPolicy(pullPolicy corev1.PullPolicy) EnvoySetup {
+	s.envoy.SetPullPolicy(pullPolicy)
+	return s
+}
+
+func (s *clusterEnvoySetup) setup() error {
+	if s.envoy.Enabled() {
+		return s.envoy.Setup()
+	}
+	return nil
+}

--- a/pkg/onit/setup/envoy.go
+++ b/pkg/onit/setup/envoy.go
@@ -33,6 +33,9 @@ type EnvoySetup interface {
 
 	// SetPullPolicy sets the image pull policy
 	SetPullPolicy(pullPolicy corev1.PullPolicy) EnvoySetup
+
+	// SetConfigMaps sets the config maps
+	SetConfigMaps(map[string]string) EnvoySetup
 }
 
 var _ EnvoySetup = &clusterEnvoySetup{}
@@ -59,6 +62,11 @@ func (s *clusterEnvoySetup) SetImage(image string) EnvoySetup {
 
 func (s *clusterEnvoySetup) SetPullPolicy(pullPolicy corev1.PullPolicy) EnvoySetup {
 	s.envoy.SetPullPolicy(pullPolicy)
+	return s
+}
+
+func (s *clusterEnvoySetup) SetConfigMaps(configMaps map[string]string) EnvoySetup {
+	s.envoy.SetConfigMaps(configMaps)
 	return s
 }
 

--- a/pkg/onit/setup/gui.go
+++ b/pkg/onit/setup/gui.go
@@ -65,7 +65,15 @@ func (s *clusterGuiSetup) SetPullPolicy(pullPolicy corev1.PullPolicy) GuiSetup {
 
 func (s *clusterGuiSetup) setup() error {
 	if s.gui.Enabled() {
-		err := s.gui.Setup()
+		err := s.gui.OnosConfig.Setup()
+		if err != nil {
+			return err
+		}
+		err = s.gui.OnosTopo.Setup()
+		if err != nil {
+			return err
+		}
+		err = s.gui.Setup()
 		if err != nil {
 			return err
 		}

--- a/pkg/onit/setup/gui.go
+++ b/pkg/onit/setup/gui.go
@@ -63,6 +63,8 @@ func (s *clusterGuiSetup) SetPullPolicy(pullPolicy corev1.PullPolicy) GuiSetup {
 }
 
 func (s *clusterGuiSetup) setup() error {
-	return s.gui.Setup()
-
+	if s.gui.Enabled() {
+		return s.gui.Setup()
+	}
+	return nil
 }

--- a/pkg/onit/setup/gui.go
+++ b/pkg/onit/setup/gui.go
@@ -1,0 +1,68 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"github.com/onosproject/onos-test/pkg/onit/cluster"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GuiSetup is an interface for setting up gui nodes
+type GuiSetup interface {
+
+	// SetEnabled enables the Gui
+	SetEnabled() GuiSetup
+
+	// SetReplicas sets the number of onos-gui replicas to deploy
+	SetReplicas(replicas int) GuiSetup
+
+	// SetImage sets the onos-gui image to deploy
+	SetImage(image string) GuiSetup
+
+	// SetPullPolicy sets the image pull policy
+	SetPullPolicy(pullPolicy corev1.PullPolicy) GuiSetup
+}
+
+var _ GuiSetup = &clusterGuiSetup{}
+
+// clusterGuiSetup is an implementation of the Gui interface
+type clusterGuiSetup struct {
+	gui *cluster.Gui
+}
+
+func (s *clusterGuiSetup) SetEnabled() GuiSetup {
+	s.gui.SetEnabled(true)
+	return s
+}
+
+func (s *clusterGuiSetup) SetReplicas(replicas int) GuiSetup {
+	s.gui.SetReplicas(replicas)
+	return s
+}
+
+func (s *clusterGuiSetup) SetImage(image string) GuiSetup {
+	s.gui.SetImage(image)
+	return s
+}
+
+func (s *clusterGuiSetup) SetPullPolicy(pullPolicy corev1.PullPolicy) GuiSetup {
+	s.gui.SetPullPolicy(pullPolicy)
+	return s
+}
+
+func (s *clusterGuiSetup) setup() error {
+	return s.gui.Setup()
+
+}

--- a/pkg/onit/setup/gui.go
+++ b/pkg/onit/setup/gui.go
@@ -16,6 +16,7 @@ package setup
 
 import (
 	"github.com/onosproject/onos-test/pkg/onit/cluster"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -64,7 +65,10 @@ func (s *clusterGuiSetup) SetPullPolicy(pullPolicy corev1.PullPolicy) GuiSetup {
 
 func (s *clusterGuiSetup) setup() error {
 	if s.gui.Enabled() {
-		return s.gui.Setup()
+		err := s.gui.Setup()
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/onit/setup/setup.go
+++ b/pkg/onit/setup/setup.go
@@ -218,7 +218,6 @@ func (s *clusterSetup) Setup() error {
 	setupService(s.Topo().(serviceSetup), wg, errCh)
 	setupService(s.Config().(serviceSetup), wg, errCh)
 	setupService(s.Gui().(serviceSetup), wg, errCh)
-	setupService(s.Envoy().(serviceSetup), wg, errCh)
 
 	for _, app := range s.apps {
 		setupService(app.(serviceSetup), wg, errCh)

--- a/pkg/onit/setup/setup.go
+++ b/pkg/onit/setup/setup.go
@@ -60,6 +60,11 @@ func App(name string) AppSetup {
 	return getSetup().App(name)
 }
 
+// Envoy returns the setup configuration for an envoy
+func Envoy(name string) EnvoySetup {
+	return getSetup().Envoy()
+}
+
 // Topo returns the setup configuration for the topo service
 func Topo() TopoSetup {
 	return getSetup().Topo()
@@ -104,6 +109,9 @@ type ClusterSetup interface {
 
 	// Gui returns the setup configuration for the ONOS gui service
 	Gui() GuiSetup
+
+	// Envoy returns the setup configuration for the envoy proxy service
+	Envoy() EnvoySetup
 
 	// App returns the setup configuration for an application
 	App(name string) AppSetup
@@ -172,6 +180,13 @@ func (s *clusterSetup) Gui() GuiSetup {
 	}
 }
 
+func (s *clusterSetup) Envoy() EnvoySetup {
+	return &clusterEnvoySetup{
+		envoy: s.cluster.Envoy(),
+	}
+
+}
+
 func (s *clusterSetup) App(name string) AppSetup {
 	if app, ok := s.apps[name]; ok {
 		return app
@@ -203,6 +218,8 @@ func (s *clusterSetup) Setup() error {
 	setupService(s.Topo().(serviceSetup), wg, errCh)
 	setupService(s.Config().(serviceSetup), wg, errCh)
 	setupService(s.Gui().(serviceSetup), wg, errCh)
+	setupService(s.Envoy().(serviceSetup), wg, errCh)
+
 	for _, app := range s.apps {
 		setupService(app.(serviceSetup), wg, errCh)
 	}

--- a/pkg/onit/setup/setup.go
+++ b/pkg/onit/setup/setup.go
@@ -15,9 +15,10 @@
 package setup
 
 import (
+	"sync"
+
 	"github.com/onosproject/onos-test/pkg/kube"
 	"github.com/onosproject/onos-test/pkg/onit/cluster"
-	"sync"
 )
 
 // New returns a new onit ClusterSetup
@@ -69,6 +70,11 @@ func Config() ConfigSetup {
 	return getSetup().Config()
 }
 
+// Gui returns the setup configuration for the gui service
+func Gui() GuiSetup {
+	return getSetup().Gui()
+}
+
 // Setup sets up the cluster
 func Setup() error {
 	return getSetup().Setup()
@@ -95,6 +101,9 @@ type ClusterSetup interface {
 
 	// Config returns the setup configuration for the ONOS config service
 	Config() ConfigSetup
+
+	// Gui returns the setup configuration for the ONOS gui service
+	Gui() GuiSetup
 
 	// App returns the setup configuration for an application
 	App(name string) AppSetup
@@ -157,6 +166,12 @@ func (s *clusterSetup) Config() ConfigSetup {
 	}
 }
 
+func (s *clusterSetup) Gui() GuiSetup {
+	return &clusterGuiSetup{
+		gui: s.cluster.Gui(),
+	}
+}
+
 func (s *clusterSetup) App(name string) AppSetup {
 	if app, ok := s.apps[name]; ok {
 		return app
@@ -187,6 +202,7 @@ func (s *clusterSetup) Setup() error {
 	setupService(s.CLI().(serviceSetup), wg, errCh)
 	setupService(s.Topo().(serviceSetup), wg, errCh)
 	setupService(s.Config().(serviceSetup), wg, errCh)
+	setupService(s.Gui().(serviceSetup), wg, errCh)
 	for _, app := range s.apps {
 		setupService(app.(serviceSetup), wg, errCh)
 	}


### PR DESCRIPTION
This PR adds 

-  onos-gui setup interface that users can deploy or enable it like other subsystems. 
-  envoy setup interface that users can deploy or enable envoy proxies. This still needs more work but it works fine for onos-gui. 
-  Adds preliminary functions for creating k8s config maps and ingress resources. This part needs more work to make them more generic. 

To test :
`onit create cluster --set onos-gui.enabled=true --set onos-gui.replicas=1`

and then check k8s pods as follows:
```
onos-test git:(add_gui) kubectl get pods -n onos -w
NAME                                 READY   STATUS    RESTARTS   AGE
atomix-controller-756f86cc9c-m5bz7   1/1     Running   0          87s
database-1-0                         1/1     Running   0          84s
onos-config-7f77c68c88-8chqx         1/1     Running   0          84s
onos-config-envoy-6788bf79d7-zv4gg   1/1     Running   0          84s
onos-gui-74bfff7b99-rdc4x            1/1     Running   0          67s
onos-topo-5bdc4f568-q5cn2            1/1     Running   0          84s
onos-topo-envoy-5c884fc76c-26jnt     1/1     Running   0          76s
```

P.S. This PR is based on the orginal version of onos-gui which uses a separate envoy service for each onos subsystems (e.g. onos-config-envoy, onos-topo-envoy) but it can be changed easily to deploy one envoy service (e.g. onos-envoy) which serves both of onos-config and onos-topo. subsystems.  