### PR TITLE
Avoid non-zero exit codes when tests succeed

### DIFF
--- a/pkg/benchmark/coordinator.go
+++ b/pkg/benchmark/coordinator.go
@@ -193,7 +193,7 @@ func (t *WorkerTask) createWorkers() error {
 
 // createWorker creates the given worker
 func (t *WorkerTask) createWorker(worker int) error {
-	env := t.config.Env
+	env := t.config.ToEnv()
 	env[benchmarkContextEnv] = string(benchmarkContextWorker)
 	env[benchmarkNamespaceEnv] = t.config.ID
 	env[benchmarkJobEnv] = t.config.ID


### PR DESCRIPTION
Tests can often exit with a non-zero exit code because containers are not in the expected state immediately following the log stream closing. This PR avoids that.