### PR TITLE
Set command arguments rather than overriding command for onit jobs

### DIFF
--- a/pkg/cluster/runner.go
+++ b/pkg/cluster/runner.go
@@ -36,7 +36,7 @@ type Job struct {
 	ID              string
 	Image           string
 	ImagePullPolicy corev1.PullPolicy
-	Command         []string
+	Args            []string
 	Env             map[string]string
 	Timeout         time.Duration
 }
@@ -356,7 +356,7 @@ func (r *Runner) createJob(job *Job) error {
 							Name:            "job",
 							Image:           job.Image,
 							ImagePullPolicy: job.ImagePullPolicy,
-							Command:         job.Command,
+							Args:            job.Args,
 							Env:             env,
 						},
 					},

--- a/pkg/onit/cli/job.go
+++ b/pkg/onit/cli/job.go
@@ -69,7 +69,7 @@ func runInCluster(command func(cmd *cobra.Command, args []string) error) func(cm
 			ID:              fmt.Sprintf("onit-%s", random.NewPetName(2)),
 			Image:           onitImage,
 			ImagePullPolicy: onitPullPolicy,
-			Command:         append([]string{"onit"}, os.Args[1:]...),
+			Args:            os.Args[1:],
 			Env: map[string]string{
 				cliContextEnv: string(k8sContext),
 			},


### PR DESCRIPTION
This PR sets the k8s `Job` args rather than overwriting the entire command when running `onit` commands inside k8s jobs.