### PR TITLE
Ensure benchmarks can deploy and manage multiple workers

### DIFF
--- a/pkg/benchmark/benchmark.pb.go
+++ b/pkg/benchmark/benchmark.pb.go
@@ -31,26 +31,26 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// Request is a benchmark request
-type Request struct {
-	// Benchmark is the benchmark to run
-	Benchmark string `protobuf:"bytes,1,opt,name=benchmark,proto3" json:"benchmark,omitempty"`
-	// Requests is the number of requests to run
-	Requests uint32 `protobuf:"varint,2,opt,name=requests,proto3" json:"requests,omitempty"`
+// SuiteRequest is a benchmark suite request
+type SuiteRequest struct {
+	// suite is the benchmark suite
+	Suite string `protobuf:"bytes,1,opt,name=suite,proto3" json:"suite,omitempty"`
+	// args is the benchmark arguments
+	Args map[string]string `protobuf:"bytes,2,rep,name=args,proto3" json:"args,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
-func (m *Request) Reset()         { *m = Request{} }
-func (m *Request) String() string { return proto.CompactTextString(m) }
-func (*Request) ProtoMessage()    {}
-func (*Request) Descriptor() ([]byte, []int) {
+func (m *SuiteRequest) Reset()         { *m = SuiteRequest{} }
+func (m *SuiteRequest) String() string { return proto.CompactTextString(m) }
+func (*SuiteRequest) ProtoMessage()    {}
+func (*SuiteRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_31dca67ba579dd0a, []int{0}
 }
-func (m *Request) XXX_Unmarshal(b []byte) error {
+func (m *SuiteRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *SuiteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_Request.Marshal(b, m, deterministic)
+		return xxx_messageInfo_SuiteRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -60,59 +60,149 @@ func (m *Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Request.Merge(m, src)
+func (m *SuiteRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SuiteRequest.Merge(m, src)
 }
-func (m *Request) XXX_Size() int {
+func (m *SuiteRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *Request) XXX_DiscardUnknown() {
-	xxx_messageInfo_Request.DiscardUnknown(m)
+func (m *SuiteRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SuiteRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Request proto.InternalMessageInfo
+var xxx_messageInfo_SuiteRequest proto.InternalMessageInfo
 
-func (m *Request) GetBenchmark() string {
+func (m *SuiteRequest) GetSuite() string {
+	if m != nil {
+		return m.Suite
+	}
+	return ""
+}
+
+func (m *SuiteRequest) GetArgs() map[string]string {
+	if m != nil {
+		return m.Args
+	}
+	return nil
+}
+
+// SuiteResponse is a response to a SuiteRequest
+type SuiteResponse struct {
+}
+
+func (m *SuiteResponse) Reset()         { *m = SuiteResponse{} }
+func (m *SuiteResponse) String() string { return proto.CompactTextString(m) }
+func (*SuiteResponse) ProtoMessage()    {}
+func (*SuiteResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_31dca67ba579dd0a, []int{1}
+}
+func (m *SuiteResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *SuiteResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_SuiteResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *SuiteResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SuiteResponse.Merge(m, src)
+}
+func (m *SuiteResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *SuiteResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SuiteResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SuiteResponse proto.InternalMessageInfo
+
+// BenchmarkRequest is a benchmark request
+type BenchmarkRequest struct {
+	// suite is the benchmark suite
+	Suite string `protobuf:"bytes,1,opt,name=suite,proto3" json:"suite,omitempty"`
+	// benchmark is the benchmark to run
+	Benchmark string `protobuf:"bytes,2,opt,name=benchmark,proto3" json:"benchmark,omitempty"`
+	// args is the benchmark arguments
+	Args map[string]string `protobuf:"bytes,3,rep,name=args,proto3" json:"args,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (m *BenchmarkRequest) Reset()         { *m = BenchmarkRequest{} }
+func (m *BenchmarkRequest) String() string { return proto.CompactTextString(m) }
+func (*BenchmarkRequest) ProtoMessage()    {}
+func (*BenchmarkRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_31dca67ba579dd0a, []int{2}
+}
+func (m *BenchmarkRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *BenchmarkRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_BenchmarkRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *BenchmarkRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BenchmarkRequest.Merge(m, src)
+}
+func (m *BenchmarkRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *BenchmarkRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_BenchmarkRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_BenchmarkRequest proto.InternalMessageInfo
+
+func (m *BenchmarkRequest) GetSuite() string {
+	if m != nil {
+		return m.Suite
+	}
+	return ""
+}
+
+func (m *BenchmarkRequest) GetBenchmark() string {
 	if m != nil {
 		return m.Benchmark
 	}
 	return ""
 }
 
-func (m *Request) GetRequests() uint32 {
+func (m *BenchmarkRequest) GetArgs() map[string]string {
 	if m != nil {
-		return m.Requests
+		return m.Args
 	}
-	return 0
+	return nil
 }
 
-// Result is a benchmark result
-type Result struct {
-	// requests is the number of requests that were run
-	Requests uint32 `protobuf:"varint,1,opt,name=requests,proto3" json:"requests,omitempty"`
-	// duration is the duration of the test run
-	Duration time.Duration `protobuf:"bytes,2,opt,name=duration,proto3,stdduration" json:"duration"`
-	// latency is the mean latency
-	Latency time.Duration `protobuf:"bytes,3,opt,name=latency,proto3,stdduration" json:"latency"`
-	// latency* are latency percentiles
-	Latency50 time.Duration `protobuf:"bytes,4,opt,name=latency50,proto3,stdduration" json:"latency50"`
-	Latency75 time.Duration `protobuf:"bytes,5,opt,name=latency75,proto3,stdduration" json:"latency75"`
-	Latency95 time.Duration `protobuf:"bytes,6,opt,name=latency95,proto3,stdduration" json:"latency95"`
-	Latency99 time.Duration `protobuf:"bytes,7,opt,name=latency99,proto3,stdduration" json:"latency99"`
+// BenchmarkResponse is a benchmark response
+type BenchmarkResponse struct {
 }
 
-func (m *Result) Reset()         { *m = Result{} }
-func (m *Result) String() string { return proto.CompactTextString(m) }
-func (*Result) ProtoMessage()    {}
-func (*Result) Descriptor() ([]byte, []int) {
-	return fileDescriptor_31dca67ba579dd0a, []int{1}
+func (m *BenchmarkResponse) Reset()         { *m = BenchmarkResponse{} }
+func (m *BenchmarkResponse) String() string { return proto.CompactTextString(m) }
+func (*BenchmarkResponse) ProtoMessage()    {}
+func (*BenchmarkResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_31dca67ba579dd0a, []int{3}
 }
-func (m *Result) XXX_Unmarshal(b []byte) error {
+func (m *BenchmarkResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *Result) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *BenchmarkResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_Result.Marshal(b, m, deterministic)
+		return xxx_messageInfo_BenchmarkResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -122,61 +212,209 @@ func (m *Result) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return b[:n], nil
 	}
 }
-func (m *Result) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Result.Merge(m, src)
+func (m *BenchmarkResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BenchmarkResponse.Merge(m, src)
 }
-func (m *Result) XXX_Size() int {
+func (m *BenchmarkResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *Result) XXX_DiscardUnknown() {
-	xxx_messageInfo_Result.DiscardUnknown(m)
+func (m *BenchmarkResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_BenchmarkResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_Result proto.InternalMessageInfo
+var xxx_messageInfo_BenchmarkResponse proto.InternalMessageInfo
 
-func (m *Result) GetRequests() uint32 {
+// RunRequest is a benchmark run request
+type RunRequest struct {
+	// suite is the benchmark suite
+	Suite string `protobuf:"bytes,1,opt,name=suite,proto3" json:"suite,omitempty"`
+	// benchmark is the benchmark to run
+	Benchmark string `protobuf:"bytes,2,opt,name=benchmark,proto3" json:"benchmark,omitempty"`
+	// requests is the number of requests to run
+	Requests uint32 `protobuf:"varint,3,opt,name=requests,proto3" json:"requests,omitempty"`
+	// parallelism is the benchmark parallelism
+	Parallelism uint32 `protobuf:"varint,4,opt,name=parallelism,proto3" json:"parallelism,omitempty"`
+	// args is the benchmark arguments
+	Args map[string]string `protobuf:"bytes,5,rep,name=args,proto3" json:"args,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+}
+
+func (m *RunRequest) Reset()         { *m = RunRequest{} }
+func (m *RunRequest) String() string { return proto.CompactTextString(m) }
+func (*RunRequest) ProtoMessage()    {}
+func (*RunRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_31dca67ba579dd0a, []int{4}
+}
+func (m *RunRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RunRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RunRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RunRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RunRequest.Merge(m, src)
+}
+func (m *RunRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *RunRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_RunRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RunRequest proto.InternalMessageInfo
+
+func (m *RunRequest) GetSuite() string {
+	if m != nil {
+		return m.Suite
+	}
+	return ""
+}
+
+func (m *RunRequest) GetBenchmark() string {
+	if m != nil {
+		return m.Benchmark
+	}
+	return ""
+}
+
+func (m *RunRequest) GetRequests() uint32 {
 	if m != nil {
 		return m.Requests
 	}
 	return 0
 }
 
-func (m *Result) GetDuration() time.Duration {
+func (m *RunRequest) GetParallelism() uint32 {
+	if m != nil {
+		return m.Parallelism
+	}
+	return 0
+}
+
+func (m *RunRequest) GetArgs() map[string]string {
+	if m != nil {
+		return m.Args
+	}
+	return nil
+}
+
+// RunResponse is a benchmark run response
+type RunResponse struct {
+	// suite is the benchmark suite
+	Suite string `protobuf:"bytes,1,opt,name=suite,proto3" json:"suite,omitempty"`
+	// benchmark is the benchmark that was run
+	Benchmark string `protobuf:"bytes,2,opt,name=benchmark,proto3" json:"benchmark,omitempty"`
+	// requests is the number of requests that were run
+	Requests uint32 `protobuf:"varint,3,opt,name=requests,proto3" json:"requests,omitempty"`
+	// duration is the duration of the test run
+	Duration time.Duration `protobuf:"bytes,4,opt,name=duration,proto3,stdduration" json:"duration"`
+	// latency is the mean latency
+	Latency time.Duration `protobuf:"bytes,5,opt,name=latency,proto3,stdduration" json:"latency"`
+	// latency* are latency percentiles
+	Latency50 time.Duration `protobuf:"bytes,6,opt,name=latency50,proto3,stdduration" json:"latency50"`
+	Latency75 time.Duration `protobuf:"bytes,7,opt,name=latency75,proto3,stdduration" json:"latency75"`
+	Latency95 time.Duration `protobuf:"bytes,8,opt,name=latency95,proto3,stdduration" json:"latency95"`
+	Latency99 time.Duration `protobuf:"bytes,9,opt,name=latency99,proto3,stdduration" json:"latency99"`
+}
+
+func (m *RunResponse) Reset()         { *m = RunResponse{} }
+func (m *RunResponse) String() string { return proto.CompactTextString(m) }
+func (*RunResponse) ProtoMessage()    {}
+func (*RunResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_31dca67ba579dd0a, []int{5}
+}
+func (m *RunResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *RunResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_RunResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *RunResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RunResponse.Merge(m, src)
+}
+func (m *RunResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *RunResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_RunResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RunResponse proto.InternalMessageInfo
+
+func (m *RunResponse) GetSuite() string {
+	if m != nil {
+		return m.Suite
+	}
+	return ""
+}
+
+func (m *RunResponse) GetBenchmark() string {
+	if m != nil {
+		return m.Benchmark
+	}
+	return ""
+}
+
+func (m *RunResponse) GetRequests() uint32 {
+	if m != nil {
+		return m.Requests
+	}
+	return 0
+}
+
+func (m *RunResponse) GetDuration() time.Duration {
 	if m != nil {
 		return m.Duration
 	}
 	return 0
 }
 
-func (m *Result) GetLatency() time.Duration {
+func (m *RunResponse) GetLatency() time.Duration {
 	if m != nil {
 		return m.Latency
 	}
 	return 0
 }
 
-func (m *Result) GetLatency50() time.Duration {
+func (m *RunResponse) GetLatency50() time.Duration {
 	if m != nil {
 		return m.Latency50
 	}
 	return 0
 }
 
-func (m *Result) GetLatency75() time.Duration {
+func (m *RunResponse) GetLatency75() time.Duration {
 	if m != nil {
 		return m.Latency75
 	}
 	return 0
 }
 
-func (m *Result) GetLatency95() time.Duration {
+func (m *RunResponse) GetLatency95() time.Duration {
 	if m != nil {
 		return m.Latency95
 	}
 	return 0
 }
 
-func (m *Result) GetLatency99() time.Duration {
+func (m *RunResponse) GetLatency99() time.Duration {
 	if m != nil {
 		return m.Latency99
 	}
@@ -184,35 +422,56 @@ func (m *Result) GetLatency99() time.Duration {
 }
 
 func init() {
-	proto.RegisterType((*Request)(nil), "onos.test.benchmark.Request")
-	proto.RegisterType((*Result)(nil), "onos.test.benchmark.Result")
+	proto.RegisterType((*SuiteRequest)(nil), "onos.test.benchmark.SuiteRequest")
+	proto.RegisterMapType((map[string]string)(nil), "onos.test.benchmark.SuiteRequest.ArgsEntry")
+	proto.RegisterType((*SuiteResponse)(nil), "onos.test.benchmark.SuiteResponse")
+	proto.RegisterType((*BenchmarkRequest)(nil), "onos.test.benchmark.BenchmarkRequest")
+	proto.RegisterMapType((map[string]string)(nil), "onos.test.benchmark.BenchmarkRequest.ArgsEntry")
+	proto.RegisterType((*BenchmarkResponse)(nil), "onos.test.benchmark.BenchmarkResponse")
+	proto.RegisterType((*RunRequest)(nil), "onos.test.benchmark.RunRequest")
+	proto.RegisterMapType((map[string]string)(nil), "onos.test.benchmark.RunRequest.ArgsEntry")
+	proto.RegisterType((*RunResponse)(nil), "onos.test.benchmark.RunResponse")
 }
 
 func init() { proto.RegisterFile("benchmark/benchmark.proto", fileDescriptor_31dca67ba579dd0a) }
 
 var fileDescriptor_31dca67ba579dd0a = []byte{
-	// 325 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x4c, 0x4a, 0xcd, 0x4b,
-	0xce, 0xc8, 0x4d, 0x2c, 0xca, 0xd6, 0x87, 0xb3, 0xf4, 0x0a, 0x8a, 0xf2, 0x4b, 0xf2, 0x85, 0x84,
-	0xf3, 0xf3, 0xf2, 0x8b, 0xf5, 0x4a, 0x52, 0x8b, 0x4b, 0xf4, 0xe0, 0x52, 0x52, 0x22, 0xe9, 0xf9,
-	0xe9, 0xf9, 0x60, 0x79, 0x7d, 0x10, 0x0b, 0xa2, 0x54, 0x4a, 0x2e, 0x3d, 0x3f, 0x3f, 0x3d, 0x27,
-	0x55, 0x1f, 0xcc, 0x4b, 0x2a, 0x4d, 0xd3, 0x4f, 0x29, 0x2d, 0x4a, 0x2c, 0xc9, 0xcc, 0xcf, 0x83,
-	0xc8, 0x2b, 0x39, 0x73, 0xb1, 0x07, 0xa5, 0x16, 0x96, 0xa6, 0x16, 0x97, 0x08, 0xc9, 0x70, 0x71,
-	0xc2, 0x4d, 0x93, 0x60, 0x54, 0x60, 0xd4, 0xe0, 0x0c, 0x42, 0x08, 0x08, 0x49, 0x71, 0x71, 0x14,
-	0x41, 0x14, 0x16, 0x4b, 0x30, 0x29, 0x30, 0x6a, 0xf0, 0x06, 0xc1, 0xf9, 0x4a, 0x1b, 0x98, 0xb9,
-	0xd8, 0x82, 0x52, 0x8b, 0x4b, 0x73, 0x4a, 0x50, 0x94, 0x31, 0xa2, 0x2a, 0x13, 0xb2, 0xe7, 0xe2,
-	0x80, 0xd9, 0x0e, 0x36, 0x82, 0xdb, 0x48, 0x52, 0x0f, 0xe2, 0x3c, 0x3d, 0x98, 0xf3, 0xf4, 0x5c,
-	0xa0, 0x0a, 0x9c, 0x38, 0x4e, 0xdc, 0x93, 0x67, 0x98, 0x71, 0x5f, 0x9e, 0x31, 0x08, 0xae, 0x49,
-	0xc8, 0x96, 0x8b, 0x3d, 0x27, 0xb1, 0x24, 0x35, 0x2f, 0xb9, 0x52, 0x82, 0x99, 0x78, 0xfd, 0x30,
-	0x3d, 0x42, 0x8e, 0x5c, 0x9c, 0x50, 0xa6, 0xa9, 0x81, 0x04, 0x0b, 0xf1, 0x06, 0x20, 0x74, 0x21,
-	0x19, 0x61, 0x6e, 0x2a, 0xc1, 0x4a, 0xba, 0x11, 0xe6, 0xa6, 0x48, 0x46, 0x58, 0x9a, 0x4a, 0xb0,
-	0x91, 0x6e, 0x84, 0x25, 0x8a, 0x11, 0x96, 0x12, 0xec, 0x64, 0x18, 0x61, 0x69, 0x14, 0xc5, 0xc5,
-	0x1b, 0x9e, 0x5f, 0x94, 0x9d, 0x5a, 0x14, 0x9c, 0x5a, 0x54, 0x96, 0x99, 0x9c, 0x2a, 0xe4, 0xc9,
-	0xc5, 0x13, 0x54, 0x9a, 0xe7, 0x04, 0x8f, 0x6f, 0x19, 0x3d, 0x2c, 0x89, 0x4c, 0x0f, 0x9a, 0x56,
-	0xa4, 0xa4, 0x71, 0xc8, 0x82, 0xd2, 0x80, 0x93, 0xc4, 0x89, 0x47, 0x72, 0x8c, 0x17, 0x1e, 0xc9,
-	0x31, 0x3e, 0x78, 0x24, 0xc7, 0x38, 0xe1, 0xb1, 0x1c, 0xc3, 0x85, 0xc7, 0x72, 0x0c, 0x37, 0x1e,
-	0xcb, 0x31, 0x24, 0xb1, 0x81, 0x5d, 0x67, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0x9f, 0x42, 0x17,
-	0xcf, 0xdc, 0x02, 0x00, 0x00,
+	// 556 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x94, 0x41, 0x6f, 0xd3, 0x30,
+	0x14, 0xc7, 0xeb, 0x76, 0xdd, 0xda, 0x97, 0x75, 0x6c, 0xde, 0x0e, 0x5e, 0x84, 0xd2, 0x52, 0x09,
+	0x54, 0x84, 0x94, 0xa0, 0xa2, 0xaa, 0x14, 0x69, 0x9a, 0x56, 0xc6, 0x07, 0x20, 0x9d, 0xd8, 0x11,
+	0xa5, 0xc5, 0x84, 0xaa, 0x59, 0x5c, 0x9c, 0x64, 0xa8, 0x67, 0xbe, 0x00, 0x47, 0x4e, 0x7c, 0x1a,
+	0x0e, 0x3b, 0xee, 0xc8, 0x09, 0x50, 0x7b, 0xe2, 0x0b, 0x70, 0x46, 0x71, 0x9c, 0x34, 0xa0, 0xb2,
+	0x76, 0x90, 0xdd, 0xfc, 0xec, 0xf7, 0x7e, 0xef, 0xff, 0x7f, 0xb2, 0x0d, 0xfb, 0x7d, 0xea, 0x0e,
+	0xde, 0x9c, 0x59, 0x7c, 0x64, 0x24, 0x2b, 0x7d, 0xcc, 0x99, 0xcf, 0xf0, 0x2e, 0x73, 0x99, 0xa7,
+	0xfb, 0xd4, 0xf3, 0xf5, 0xe4, 0x48, 0xdd, 0xb3, 0x99, 0xcd, 0xc4, 0xb9, 0x11, 0xae, 0xa2, 0x54,
+	0x55, 0xb3, 0x19, 0xb3, 0x1d, 0x6a, 0x88, 0xa8, 0x1f, 0xbc, 0x36, 0x5e, 0x05, 0xdc, 0xf2, 0x87,
+	0xcc, 0x8d, 0xce, 0xeb, 0x9f, 0x10, 0x6c, 0xf6, 0x82, 0xa1, 0x4f, 0x4d, 0xfa, 0x36, 0xa0, 0x9e,
+	0x8f, 0xf7, 0xa0, 0xe8, 0x85, 0x31, 0x41, 0x35, 0xd4, 0x28, 0x9b, 0x51, 0x80, 0x0f, 0x61, 0xcd,
+	0xe2, 0xb6, 0x47, 0xf2, 0xb5, 0x42, 0x43, 0x69, 0x3e, 0xd0, 0x17, 0x08, 0xd0, 0xd3, 0x18, 0xfd,
+	0x88, 0xdb, 0xde, 0x33, 0xd7, 0xe7, 0x13, 0x53, 0x14, 0xaa, 0x6d, 0x28, 0x27, 0x5b, 0x78, 0x1b,
+	0x0a, 0x23, 0x3a, 0x91, 0x1d, 0xc2, 0x65, 0xd8, 0xf5, 0xdc, 0x72, 0x02, 0x4a, 0xf2, 0x51, 0x57,
+	0x11, 0x3c, 0xc9, 0x3f, 0x46, 0xf5, 0x5b, 0x50, 0x91, 0x60, 0x6f, 0xcc, 0x5c, 0x8f, 0xd6, 0x3f,
+	0x23, 0xd8, 0xee, 0xc6, 0x4d, 0xaf, 0x56, 0x7d, 0x1b, 0xca, 0x89, 0x3c, 0x49, 0x9e, 0x6f, 0xe0,
+	0xa7, 0xd2, 0x53, 0x41, 0x78, 0x32, 0x16, 0x7a, 0xfa, 0xb3, 0x51, 0x76, 0xbe, 0x76, 0x61, 0x27,
+	0x05, 0x97, 0xde, 0x7e, 0x22, 0x00, 0x33, 0x70, 0xff, 0xc7, 0x95, 0x0a, 0x25, 0x1e, 0x95, 0x87,
+	0xce, 0x50, 0xa3, 0x62, 0x26, 0x31, 0xae, 0x81, 0x32, 0xb6, 0xb8, 0xe5, 0x38, 0xd4, 0x19, 0x7a,
+	0x67, 0x64, 0x4d, 0x1c, 0xa7, 0xb7, 0xf0, 0x81, 0x9c, 0x49, 0x51, 0xcc, 0xe4, 0xfe, 0xc2, 0x99,
+	0xcc, 0x05, 0x66, 0x37, 0x8d, 0x1f, 0x05, 0x50, 0x04, 0x37, 0x1a, 0x44, 0xe6, 0xce, 0x0f, 0xa1,
+	0x14, 0x5f, 0x7c, 0x61, 0x5b, 0x69, 0xee, 0xeb, 0xd1, 0xcb, 0xd0, 0xe3, 0x97, 0xa1, 0x1f, 0xcb,
+	0x84, 0x6e, 0xe9, 0xe2, 0x6b, 0x35, 0xf7, 0xf1, 0x5b, 0x15, 0x99, 0x49, 0x11, 0x3e, 0x80, 0x0d,
+	0xc7, 0xf2, 0xa9, 0x3b, 0x98, 0x90, 0xe2, 0xea, 0xf5, 0x71, 0x0d, 0x3e, 0x82, 0xb2, 0x5c, 0xb6,
+	0x1e, 0x92, 0xf5, 0xd5, 0x01, 0xf3, 0xaa, 0x14, 0xa2, 0xdd, 0x22, 0x1b, 0xd7, 0x47, 0xb4, 0x5b,
+	0x29, 0x44, 0xa7, 0x45, 0x4a, 0xd7, 0x47, 0x74, 0x7e, 0x43, 0x74, 0x48, 0xf9, 0x1f, 0x10, 0x9d,
+	0xe6, 0xfb, 0x22, 0x54, 0x4e, 0x19, 0x1f, 0x51, 0xde, 0xa3, 0xfc, 0x7c, 0x38, 0xa0, 0xb8, 0x07,
+	0xd0, 0xa3, 0x7e, 0x30, 0x16, 0x0f, 0x1d, 0xdf, 0x59, 0xfa, 0xbb, 0xa8, 0xf5, 0xab, 0x52, 0xe4,
+	0x15, 0x7a, 0x01, 0x95, 0x13, 0x6a, 0xf1, 0x63, 0xf6, 0xce, 0xcd, 0x94, 0x7b, 0x02, 0x8a, 0x10,
+	0x1b, 0x59, 0xc8, 0x8a, 0x7a, 0x0a, 0x5b, 0xb1, 0xda, 0x6c, 0xc1, 0x2f, 0x61, 0x4b, 0xc8, 0x4d,
+	0x3e, 0x1b, 0x7c, 0x77, 0xa5, 0x9f, 0x4e, 0xbd, 0xb7, 0x2c, 0x4d, 0x36, 0xe8, 0xc3, 0x4e, 0xac,
+	0xfc, 0xc6, 0x7a, 0x3c, 0x87, 0x4d, 0x33, 0x48, 0xe1, 0xab, 0x4b, 0x3e, 0x26, 0xb5, 0xf6, 0xf7,
+	0x84, 0x08, 0xd9, 0x25, 0x17, 0x53, 0x0d, 0x5d, 0x4e, 0x35, 0xf4, 0x7d, 0xaa, 0xa1, 0x0f, 0x33,
+	0x2d, 0x77, 0x39, 0xd3, 0x72, 0x5f, 0x66, 0x5a, 0xae, 0xbf, 0x2e, 0xee, 0xf1, 0xa3, 0x5f, 0x01,
+	0x00, 0x00, 0xff, 0xff, 0xac, 0xd2, 0xa5, 0x42, 0x81, 0x07, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -227,7 +486,13 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type WorkerServiceClient interface {
-	RunBenchmark(ctx context.Context, in *Request, opts ...grpc.CallOption) (*Result, error)
+	SetupSuite(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error)
+	TearDownSuite(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error)
+	SetupWorker(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error)
+	TearDownWorker(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error)
+	SetupBenchmark(ctx context.Context, in *BenchmarkRequest, opts ...grpc.CallOption) (*BenchmarkResponse, error)
+	TearDownBenchmark(ctx context.Context, in *BenchmarkRequest, opts ...grpc.CallOption) (*BenchmarkResponse, error)
+	RunBenchmark(ctx context.Context, in *RunRequest, opts ...grpc.CallOption) (*RunResponse, error)
 }
 
 type workerServiceClient struct {
@@ -238,8 +503,62 @@ func NewWorkerServiceClient(cc *grpc.ClientConn) WorkerServiceClient {
 	return &workerServiceClient{cc}
 }
 
-func (c *workerServiceClient) RunBenchmark(ctx context.Context, in *Request, opts ...grpc.CallOption) (*Result, error) {
-	out := new(Result)
+func (c *workerServiceClient) SetupSuite(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error) {
+	out := new(SuiteResponse)
+	err := c.cc.Invoke(ctx, "/onos.test.benchmark.WorkerService/SetupSuite", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *workerServiceClient) TearDownSuite(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error) {
+	out := new(SuiteResponse)
+	err := c.cc.Invoke(ctx, "/onos.test.benchmark.WorkerService/TearDownSuite", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *workerServiceClient) SetupWorker(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error) {
+	out := new(SuiteResponse)
+	err := c.cc.Invoke(ctx, "/onos.test.benchmark.WorkerService/SetupWorker", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *workerServiceClient) TearDownWorker(ctx context.Context, in *SuiteRequest, opts ...grpc.CallOption) (*SuiteResponse, error) {
+	out := new(SuiteResponse)
+	err := c.cc.Invoke(ctx, "/onos.test.benchmark.WorkerService/TearDownWorker", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *workerServiceClient) SetupBenchmark(ctx context.Context, in *BenchmarkRequest, opts ...grpc.CallOption) (*BenchmarkResponse, error) {
+	out := new(BenchmarkResponse)
+	err := c.cc.Invoke(ctx, "/onos.test.benchmark.WorkerService/SetupBenchmark", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *workerServiceClient) TearDownBenchmark(ctx context.Context, in *BenchmarkRequest, opts ...grpc.CallOption) (*BenchmarkResponse, error) {
+	out := new(BenchmarkResponse)
+	err := c.cc.Invoke(ctx, "/onos.test.benchmark.WorkerService/TearDownBenchmark", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *workerServiceClient) RunBenchmark(ctx context.Context, in *RunRequest, opts ...grpc.CallOption) (*RunResponse, error) {
+	out := new(RunResponse)
 	err := c.cc.Invoke(ctx, "/onos.test.benchmark.WorkerService/RunBenchmark", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -249,14 +568,38 @@ func (c *workerServiceClient) RunBenchmark(ctx context.Context, in *Request, opt
 
 // WorkerServiceServer is the server API for WorkerService service.
 type WorkerServiceServer interface {
-	RunBenchmark(context.Context, *Request) (*Result, error)
+	SetupSuite(context.Context, *SuiteRequest) (*SuiteResponse, error)
+	TearDownSuite(context.Context, *SuiteRequest) (*SuiteResponse, error)
+	SetupWorker(context.Context, *SuiteRequest) (*SuiteResponse, error)
+	TearDownWorker(context.Context, *SuiteRequest) (*SuiteResponse, error)
+	SetupBenchmark(context.Context, *BenchmarkRequest) (*BenchmarkResponse, error)
+	TearDownBenchmark(context.Context, *BenchmarkRequest) (*BenchmarkResponse, error)
+	RunBenchmark(context.Context, *RunRequest) (*RunResponse, error)
 }
 
 // UnimplementedWorkerServiceServer can be embedded to have forward compatible implementations.
 type UnimplementedWorkerServiceServer struct {
 }
 
-func (*UnimplementedWorkerServiceServer) RunBenchmark(ctx context.Context, req *Request) (*Result, error) {
+func (*UnimplementedWorkerServiceServer) SetupSuite(ctx context.Context, req *SuiteRequest) (*SuiteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetupSuite not implemented")
+}
+func (*UnimplementedWorkerServiceServer) TearDownSuite(ctx context.Context, req *SuiteRequest) (*SuiteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TearDownSuite not implemented")
+}
+func (*UnimplementedWorkerServiceServer) SetupWorker(ctx context.Context, req *SuiteRequest) (*SuiteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetupWorker not implemented")
+}
+func (*UnimplementedWorkerServiceServer) TearDownWorker(ctx context.Context, req *SuiteRequest) (*SuiteResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TearDownWorker not implemented")
+}
+func (*UnimplementedWorkerServiceServer) SetupBenchmark(ctx context.Context, req *BenchmarkRequest) (*BenchmarkResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetupBenchmark not implemented")
+}
+func (*UnimplementedWorkerServiceServer) TearDownBenchmark(ctx context.Context, req *BenchmarkRequest) (*BenchmarkResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method TearDownBenchmark not implemented")
+}
+func (*UnimplementedWorkerServiceServer) RunBenchmark(ctx context.Context, req *RunRequest) (*RunResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method RunBenchmark not implemented")
 }
 
@@ -264,8 +607,116 @@ func RegisterWorkerServiceServer(s *grpc.Server, srv WorkerServiceServer) {
 	s.RegisterService(&_WorkerService_serviceDesc, srv)
 }
 
+func _WorkerService_SetupSuite_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SuiteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorkerServiceServer).SetupSuite(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/onos.test.benchmark.WorkerService/SetupSuite",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorkerServiceServer).SetupSuite(ctx, req.(*SuiteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorkerService_TearDownSuite_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SuiteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorkerServiceServer).TearDownSuite(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/onos.test.benchmark.WorkerService/TearDownSuite",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorkerServiceServer).TearDownSuite(ctx, req.(*SuiteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorkerService_SetupWorker_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SuiteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorkerServiceServer).SetupWorker(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/onos.test.benchmark.WorkerService/SetupWorker",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorkerServiceServer).SetupWorker(ctx, req.(*SuiteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorkerService_TearDownWorker_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SuiteRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorkerServiceServer).TearDownWorker(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/onos.test.benchmark.WorkerService/TearDownWorker",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorkerServiceServer).TearDownWorker(ctx, req.(*SuiteRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorkerService_SetupBenchmark_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BenchmarkRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorkerServiceServer).SetupBenchmark(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/onos.test.benchmark.WorkerService/SetupBenchmark",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorkerServiceServer).SetupBenchmark(ctx, req.(*BenchmarkRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _WorkerService_TearDownBenchmark_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BenchmarkRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorkerServiceServer).TearDownBenchmark(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/onos.test.benchmark.WorkerService/TearDownBenchmark",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorkerServiceServer).TearDownBenchmark(ctx, req.(*BenchmarkRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _WorkerService_RunBenchmark_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(Request)
+	in := new(RunRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -277,7 +728,7 @@ func _WorkerService_RunBenchmark_Handler(srv interface{}, ctx context.Context, d
 		FullMethod: "/onos.test.benchmark.WorkerService/RunBenchmark",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(WorkerServiceServer).RunBenchmark(ctx, req.(*Request))
+		return srv.(WorkerServiceServer).RunBenchmark(ctx, req.(*RunRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -287,6 +738,30 @@ var _WorkerService_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*WorkerServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
+			MethodName: "SetupSuite",
+			Handler:    _WorkerService_SetupSuite_Handler,
+		},
+		{
+			MethodName: "TearDownSuite",
+			Handler:    _WorkerService_TearDownSuite_Handler,
+		},
+		{
+			MethodName: "SetupWorker",
+			Handler:    _WorkerService_SetupWorker_Handler,
+		},
+		{
+			MethodName: "TearDownWorker",
+			Handler:    _WorkerService_TearDownWorker_Handler,
+		},
+		{
+			MethodName: "SetupBenchmark",
+			Handler:    _WorkerService_SetupBenchmark_Handler,
+		},
+		{
+			MethodName: "TearDownBenchmark",
+			Handler:    _WorkerService_TearDownBenchmark_Handler,
+		},
+		{
 			MethodName: "RunBenchmark",
 			Handler:    _WorkerService_RunBenchmark_Handler,
 		},
@@ -295,7 +770,7 @@ var _WorkerService_serviceDesc = grpc.ServiceDesc{
 	Metadata: "benchmark/benchmark.proto",
 }
 
-func (m *Request) Marshal() (dAtA []byte, err error) {
+func (m *SuiteRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -305,32 +780,46 @@ func (m *Request) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *Request) MarshalTo(dAtA []byte) (int, error) {
+func (m *SuiteRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *Request) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *SuiteRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Requests != 0 {
-		i = encodeVarintBenchmark(dAtA, i, uint64(m.Requests))
-		i--
-		dAtA[i] = 0x10
+	if len(m.Args) > 0 {
+		for k := range m.Args {
+			v := m.Args[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintBenchmark(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintBenchmark(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintBenchmark(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x12
+		}
 	}
-	if len(m.Benchmark) > 0 {
-		i -= len(m.Benchmark)
-		copy(dAtA[i:], m.Benchmark)
-		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Benchmark)))
+	if len(m.Suite) > 0 {
+		i -= len(m.Suite)
+		copy(dAtA[i:], m.Suite)
+		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Suite)))
 		i--
 		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
 
-func (m *Result) Marshal() (dAtA []byte, err error) {
+func (m *SuiteResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -340,12 +829,180 @@ func (m *Result) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *Result) MarshalTo(dAtA []byte) (int, error) {
+func (m *SuiteResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *Result) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *SuiteResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *BenchmarkRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BenchmarkRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BenchmarkRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Args) > 0 {
+		for k := range m.Args {
+			v := m.Args[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintBenchmark(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintBenchmark(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintBenchmark(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Benchmark) > 0 {
+		i -= len(m.Benchmark)
+		copy(dAtA[i:], m.Benchmark)
+		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Benchmark)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Suite) > 0 {
+		i -= len(m.Suite)
+		copy(dAtA[i:], m.Suite)
+		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Suite)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *BenchmarkResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *BenchmarkResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BenchmarkResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
+func (m *RunRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RunRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RunRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Args) > 0 {
+		for k := range m.Args {
+			v := m.Args[k]
+			baseI := i
+			i -= len(v)
+			copy(dAtA[i:], v)
+			i = encodeVarintBenchmark(dAtA, i, uint64(len(v)))
+			i--
+			dAtA[i] = 0x12
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintBenchmark(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintBenchmark(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x2a
+		}
+	}
+	if m.Parallelism != 0 {
+		i = encodeVarintBenchmark(dAtA, i, uint64(m.Parallelism))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Requests != 0 {
+		i = encodeVarintBenchmark(dAtA, i, uint64(m.Requests))
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Benchmark) > 0 {
+		i -= len(m.Benchmark)
+		copy(dAtA[i:], m.Benchmark)
+		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Benchmark)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Suite) > 0 {
+		i -= len(m.Suite)
+		copy(dAtA[i:], m.Suite)
+		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Suite)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *RunResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RunResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *RunResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -357,7 +1014,7 @@ func (m *Result) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i -= n1
 	i = encodeVarintBenchmark(dAtA, i, uint64(n1))
 	i--
-	dAtA[i] = 0x3a
+	dAtA[i] = 0x4a
 	n2, err2 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Latency95, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Latency95):])
 	if err2 != nil {
 		return 0, err2
@@ -365,7 +1022,7 @@ func (m *Result) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i -= n2
 	i = encodeVarintBenchmark(dAtA, i, uint64(n2))
 	i--
-	dAtA[i] = 0x32
+	dAtA[i] = 0x42
 	n3, err3 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Latency75, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Latency75):])
 	if err3 != nil {
 		return 0, err3
@@ -373,7 +1030,7 @@ func (m *Result) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i -= n3
 	i = encodeVarintBenchmark(dAtA, i, uint64(n3))
 	i--
-	dAtA[i] = 0x2a
+	dAtA[i] = 0x3a
 	n4, err4 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Latency50, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Latency50):])
 	if err4 != nil {
 		return 0, err4
@@ -381,7 +1038,7 @@ func (m *Result) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i -= n4
 	i = encodeVarintBenchmark(dAtA, i, uint64(n4))
 	i--
-	dAtA[i] = 0x22
+	dAtA[i] = 0x32
 	n5, err5 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Latency, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Latency):])
 	if err5 != nil {
 		return 0, err5
@@ -389,7 +1046,7 @@ func (m *Result) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i -= n5
 	i = encodeVarintBenchmark(dAtA, i, uint64(n5))
 	i--
-	dAtA[i] = 0x1a
+	dAtA[i] = 0x2a
 	n6, err6 := github_com_gogo_protobuf_types.StdDurationMarshalTo(m.Duration, dAtA[i-github_com_gogo_protobuf_types.SizeOfStdDuration(m.Duration):])
 	if err6 != nil {
 		return 0, err6
@@ -397,11 +1054,25 @@ func (m *Result) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i -= n6
 	i = encodeVarintBenchmark(dAtA, i, uint64(n6))
 	i--
-	dAtA[i] = 0x12
+	dAtA[i] = 0x22
 	if m.Requests != 0 {
 		i = encodeVarintBenchmark(dAtA, i, uint64(m.Requests))
 		i--
-		dAtA[i] = 0x8
+		dAtA[i] = 0x18
+	}
+	if len(m.Benchmark) > 0 {
+		i -= len(m.Benchmark)
+		copy(dAtA[i:], m.Benchmark)
+		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Benchmark)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.Suite) > 0 {
+		i -= len(m.Suite)
+		copy(dAtA[i:], m.Suite)
+		i = encodeVarintBenchmark(dAtA, i, uint64(len(m.Suite)))
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -417,12 +1088,80 @@ func encodeVarintBenchmark(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *Request) Size() (n int) {
+func (m *SuiteRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
+	l = len(m.Suite)
+	if l > 0 {
+		n += 1 + l + sovBenchmark(uint64(l))
+	}
+	if len(m.Args) > 0 {
+		for k, v := range m.Args {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovBenchmark(uint64(len(k))) + 1 + len(v) + sovBenchmark(uint64(len(v)))
+			n += mapEntrySize + 1 + sovBenchmark(uint64(mapEntrySize))
+		}
+	}
+	return n
+}
+
+func (m *SuiteResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *BenchmarkRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Suite)
+	if l > 0 {
+		n += 1 + l + sovBenchmark(uint64(l))
+	}
+	l = len(m.Benchmark)
+	if l > 0 {
+		n += 1 + l + sovBenchmark(uint64(l))
+	}
+	if len(m.Args) > 0 {
+		for k, v := range m.Args {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovBenchmark(uint64(len(k))) + 1 + len(v) + sovBenchmark(uint64(len(v)))
+			n += mapEntrySize + 1 + sovBenchmark(uint64(mapEntrySize))
+		}
+	}
+	return n
+}
+
+func (m *BenchmarkResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
+func (m *RunRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Suite)
+	if l > 0 {
+		n += 1 + l + sovBenchmark(uint64(l))
+	}
 	l = len(m.Benchmark)
 	if l > 0 {
 		n += 1 + l + sovBenchmark(uint64(l))
@@ -430,15 +1169,34 @@ func (m *Request) Size() (n int) {
 	if m.Requests != 0 {
 		n += 1 + sovBenchmark(uint64(m.Requests))
 	}
+	if m.Parallelism != 0 {
+		n += 1 + sovBenchmark(uint64(m.Parallelism))
+	}
+	if len(m.Args) > 0 {
+		for k, v := range m.Args {
+			_ = k
+			_ = v
+			mapEntrySize := 1 + len(k) + sovBenchmark(uint64(len(k))) + 1 + len(v) + sovBenchmark(uint64(len(v)))
+			n += mapEntrySize + 1 + sovBenchmark(uint64(mapEntrySize))
+		}
+	}
 	return n
 }
 
-func (m *Result) Size() (n int) {
+func (m *RunResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
 	var l int
 	_ = l
+	l = len(m.Suite)
+	if l > 0 {
+		n += 1 + l + sovBenchmark(uint64(l))
+	}
+	l = len(m.Benchmark)
+	if l > 0 {
+		n += 1 + l + sovBenchmark(uint64(l))
+	}
 	if m.Requests != 0 {
 		n += 1 + sovBenchmark(uint64(m.Requests))
 	}
@@ -463,7 +1221,7 @@ func sovBenchmark(x uint64) (n int) {
 func sozBenchmark(x uint64) (n int) {
 	return sovBenchmark(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *Request) Unmarshal(dAtA []byte) error {
+func (m *SuiteRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -486,13 +1244,310 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Request: wiretype end group for non-group")
+			return fmt.Errorf("proto: SuiteRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Request: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: SuiteRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Suite", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Suite = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Args", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Args == nil {
+				m.Args = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowBenchmark
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowBenchmark
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowBenchmark
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipBenchmark(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Args[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipBenchmark(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *SuiteResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowBenchmark
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: SuiteResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: SuiteResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipBenchmark(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *BenchmarkRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowBenchmark
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: BenchmarkRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: BenchmarkRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Suite", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Suite = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Benchmark", wireType)
 			}
@@ -524,11 +1579,11 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 			}
 			m.Benchmark = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
-		case 2:
-			if wireType != 0 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Requests", wireType)
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Args", wireType)
 			}
-			m.Requests = 0
+			var msglen int
 			for shift := uint(0); ; shift += 7 {
 				if shift >= 64 {
 					return ErrIntOverflowBenchmark
@@ -538,11 +1593,119 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Requests |= uint32(b&0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
 			}
+			if msglen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Args == nil {
+				m.Args = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowBenchmark
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowBenchmark
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowBenchmark
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipBenchmark(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Args[mapkey] = mapvalue
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipBenchmark(dAtA[iNdEx:])
@@ -567,7 +1730,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *Result) Unmarshal(dAtA []byte) error {
+func (m *BenchmarkResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -590,13 +1753,130 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: Result: wiretype end group for non-group")
+			return fmt.Errorf("proto: BenchmarkResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: Result: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: BenchmarkResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipBenchmark(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RunRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowBenchmark
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RunRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RunRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Suite", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Suite = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Benchmark", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Benchmark = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
 			if wireType != 0 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Requests", wireType)
 			}
@@ -615,7 +1895,289 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 					break
 				}
 			}
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Parallelism", wireType)
+			}
+			m.Parallelism = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Parallelism |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Args", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Args == nil {
+				m.Args = make(map[string]string)
+			}
+			var mapkey string
+			var mapvalue string
+			for iNdEx < postIndex {
+				entryPreIndex := iNdEx
+				var wire uint64
+				for shift := uint(0); ; shift += 7 {
+					if shift >= 64 {
+						return ErrIntOverflowBenchmark
+					}
+					if iNdEx >= l {
+						return io.ErrUnexpectedEOF
+					}
+					b := dAtA[iNdEx]
+					iNdEx++
+					wire |= uint64(b&0x7F) << shift
+					if b < 0x80 {
+						break
+					}
+				}
+				fieldNum := int32(wire >> 3)
+				if fieldNum == 1 {
+					var stringLenmapkey uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowBenchmark
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapkey |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapkey := int(stringLenmapkey)
+					if intStringLenmapkey < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if postStringIndexmapkey > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapkey = string(dAtA[iNdEx:postStringIndexmapkey])
+					iNdEx = postStringIndexmapkey
+				} else if fieldNum == 2 {
+					var stringLenmapvalue uint64
+					for shift := uint(0); ; shift += 7 {
+						if shift >= 64 {
+							return ErrIntOverflowBenchmark
+						}
+						if iNdEx >= l {
+							return io.ErrUnexpectedEOF
+						}
+						b := dAtA[iNdEx]
+						iNdEx++
+						stringLenmapvalue |= uint64(b&0x7F) << shift
+						if b < 0x80 {
+							break
+						}
+					}
+					intStringLenmapvalue := int(stringLenmapvalue)
+					if intStringLenmapvalue < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					postStringIndexmapvalue := iNdEx + intStringLenmapvalue
+					if postStringIndexmapvalue < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if postStringIndexmapvalue > l {
+						return io.ErrUnexpectedEOF
+					}
+					mapvalue = string(dAtA[iNdEx:postStringIndexmapvalue])
+					iNdEx = postStringIndexmapvalue
+				} else {
+					iNdEx = entryPreIndex
+					skippy, err := skipBenchmark(dAtA[iNdEx:])
+					if err != nil {
+						return err
+					}
+					if skippy < 0 {
+						return ErrInvalidLengthBenchmark
+					}
+					if (iNdEx + skippy) > postIndex {
+						return io.ErrUnexpectedEOF
+					}
+					iNdEx += skippy
+				}
+			}
+			m.Args[mapkey] = mapvalue
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipBenchmark(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RunResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowBenchmark
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RunResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RunResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Suite", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Suite = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Benchmark", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBenchmark
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Benchmark = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Requests", wireType)
+			}
+			m.Requests = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowBenchmark
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Requests |= uint32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 4:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Duration", wireType)
 			}
@@ -648,7 +2210,7 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 3:
+		case 5:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Latency", wireType)
 			}
@@ -681,7 +2243,7 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 4:
+		case 6:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Latency50", wireType)
 			}
@@ -714,7 +2276,7 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 5:
+		case 7:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Latency75", wireType)
 			}
@@ -747,7 +2309,7 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 6:
+		case 8:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Latency95", wireType)
 			}
@@ -780,7 +2342,7 @@ func (m *Result) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
-		case 7:
+		case 9:
 			if wireType != 2 {
 				return fmt.Errorf("proto: wrong wireType = %d for field Latency99", wireType)
 			}

--- a/pkg/benchmark/benchmark.proto
+++ b/pkg/benchmark/benchmark.proto
@@ -21,34 +21,86 @@ package onos.test.benchmark;
 import "gogoproto/gogo.proto";
 import "google/protobuf/duration.proto";
 
-// Request is a benchmark request
-message Request {
-    // Benchmark is the benchmark to run
-    string benchmark = 1;
+// SuiteRequest is a benchmark suite request
+message SuiteRequest {
+    // suite is the benchmark suite
+    string suite = 1;
 
-    // Requests is the number of requests to run
-    uint32 requests = 2;
+    // args is the benchmark arguments
+    map<string, string> args = 2;
 }
 
-// Result is a benchmark result
-message Result {
+// SuiteResponse is a response to a SuiteRequest
+message SuiteResponse {
+
+}
+
+// BenchmarkRequest is a benchmark request
+message BenchmarkRequest {
+    // suite is the benchmark suite
+    string suite = 1;
+
+    // benchmark is the benchmark to run
+    string benchmark = 2;
+
+    // args is the benchmark arguments
+    map<string, string> args = 3;
+}
+
+// BenchmarkResponse is a benchmark response
+message BenchmarkResponse {
+
+}
+
+// RunRequest is a benchmark run request
+message RunRequest {
+    // suite is the benchmark suite
+    string suite = 1;
+
+    // benchmark is the benchmark to run
+    string benchmark = 2;
+
+    // requests is the number of requests to run
+    uint32 requests = 3;
+
+    // parallelism is the benchmark parallelism
+    uint32 parallelism = 4;
+
+    // args is the benchmark arguments
+    map<string, string> args = 5;
+}
+
+// RunResponse is a benchmark run response
+message RunResponse {
+    // suite is the benchmark suite
+    string suite = 1;
+
+    // benchmark is the benchmark that was run
+    string benchmark = 2;
+
     // requests is the number of requests that were run
-    uint32 requests = 1;
+    uint32 requests = 3;
 
     // duration is the duration of the test run
-    google.protobuf.Duration duration = 2 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+    google.protobuf.Duration duration = 4 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
 
     // latency is the mean latency
-    google.protobuf.Duration latency = 3 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+    google.protobuf.Duration latency = 5 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
 
     // latency* are latency percentiles
-    google.protobuf.Duration latency50 = 4 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
-    google.protobuf.Duration latency75 = 5 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
-    google.protobuf.Duration latency95 = 6 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
-    google.protobuf.Duration latency99 = 7 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+    google.protobuf.Duration latency50 = 6 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+    google.protobuf.Duration latency75 = 7 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+    google.protobuf.Duration latency95 = 8 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
+    google.protobuf.Duration latency99 = 9 [(gogoproto.stdduration) = true, (gogoproto.nullable) = false];
 }
 
 // WorkerService is a benchmark worker service
 service WorkerService {
-    rpc RunBenchmark (Request) returns (Result);
+    rpc SetupSuite (SuiteRequest) returns (SuiteResponse);
+    rpc TearDownSuite (SuiteRequest) returns (SuiteResponse);
+    rpc SetupWorker (SuiteRequest) returns (SuiteResponse);
+    rpc TearDownWorker (SuiteRequest) returns (SuiteResponse);
+    rpc SetupBenchmark (BenchmarkRequest) returns (BenchmarkResponse);
+    rpc TearDownBenchmark (BenchmarkRequest) returns (BenchmarkResponse);
+    rpc RunBenchmark (RunRequest) returns (RunResponse);
 }

--- a/pkg/benchmark/config.go
+++ b/pkg/benchmark/config.go
@@ -37,6 +37,7 @@ const (
 	benchmarkParallelismEnv     = "BENCHMARK_PARALLELISM"
 	benchmarkRequestsEnv        = "BENCHMARK_REQUESTS"
 	benchmarkArgPrefix          = "BENCHMARK_ARG_"
+	benchmarkWorkerEnv          = "BENCHMARK_WORKER"
 )
 
 const (
@@ -123,4 +124,17 @@ func getBenchmarkContext() benchmarkContext {
 		return benchmarkContext(context)
 	}
 	return benchmarkContextCoordinator
+}
+
+// getBenchmarkWorker returns the current benchmark worker number
+func getBenchmarkWorker() int {
+	worker := os.Getenv(benchmarkWorkerEnv)
+	if worker == "" {
+		return 0
+	}
+	i, err := strconv.Atoi(worker)
+	if err != nil {
+		panic(err)
+	}
+	return i
 }

--- a/pkg/benchmark/worker.go
+++ b/pkg/benchmark/worker.go
@@ -16,10 +16,13 @@ package benchmark
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"github.com/onosproject/onos-test/pkg/kube"
+	"github.com/onosproject/onos-test/pkg/util/logging"
 	"google.golang.org/grpc"
 	"net"
+	"reflect"
+	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,27 +32,20 @@ func newWorker(config *Config) (*Worker, error) {
 	if err != nil {
 		return nil, err
 	}
-	suite := Registry.benchmarks[config.Suite]
-	if suite == nil {
-		return nil, errors.New("unknown benchmark suite")
-	}
 	return &Worker{
 		client: kubeAPI.Client(),
-		suite:  suite,
-		config: config,
+		suites: make(map[string]BenchmarkingSuite),
 	}, nil
 }
 
 // Worker runs a benchmark job
 type Worker struct {
 	client client.Client
-	suite  BenchmarkingSuite
-	config *Config
+	suites map[string]BenchmarkingSuite
 }
 
 // Run runs a benchmark
 func (w *Worker) Run() error {
-	setupSuite(w.suite, w.config)
 	lis, err := net.Listen("tcp", ":5000")
 	if err != nil {
 		return err
@@ -59,7 +55,162 @@ func (w *Worker) Run() error {
 	return server.Serve(lis)
 }
 
-// RunBenchmark runs a benchmark method from the given request
-func (w *Worker) RunBenchmark(ctx context.Context, request *Request) (*Result, error) {
-	return runBenchmark(request.Benchmark, int(request.Requests), w.suite, w.config)
+func (w *Worker) getSuite(name string) (BenchmarkingSuite, error) {
+	if suite, ok := w.suites[name]; ok {
+		return suite, nil
+	}
+	if suite, ok := Registry.benchmarks[name]; ok {
+		w.suites[name] = suite
+		return suite, nil
+	}
+	return nil, fmt.Errorf("unknown benchmark suite %s", name)
+}
+
+// SetupSuite sets up a benchmark suite
+func (w *Worker) SetupSuite(ctx context.Context, request *SuiteRequest) (*SuiteResponse, error) {
+	step := logging.NewStep(fmt.Sprintf("%s/%d", request.Suite, getBenchmarkWorker()), "SetupSuite %s", request.Suite)
+	step.Start()
+
+	suite, err := w.getSuite(request.Suite)
+	if err != nil {
+		step.Fail(err)
+		return nil, err
+	}
+
+	if setupSuite, ok := suite.(SetupSuite); ok {
+		setupSuite.SetupSuite(newContext(request.Suite, request.Args))
+	}
+
+	step.Complete()
+	return &SuiteResponse{}, nil
+}
+
+// TearDownSuite tears down a benchmark suite
+func (w *Worker) TearDownSuite(ctx context.Context, request *SuiteRequest) (*SuiteResponse, error) {
+	step := logging.NewStep(fmt.Sprintf("%s/%d", request.Suite, getBenchmarkWorker()), "TearDownSuite %s", request.Suite)
+	step.Start()
+
+	suite, err := w.getSuite(request.Suite)
+	if err != nil {
+		step.Fail(err)
+		return nil, err
+	}
+
+	if tearDownSuite, ok := suite.(TearDownSuite); ok {
+		tearDownSuite.TearDownSuite(newContext(request.Suite, request.Args))
+	}
+
+	step.Complete()
+	return &SuiteResponse{}, nil
+}
+
+// SetupWorker sets up a benchmark worker
+func (w *Worker) SetupWorker(ctx context.Context, request *SuiteRequest) (*SuiteResponse, error) {
+	step := logging.NewStep(fmt.Sprintf("%s/%d", request.Suite, getBenchmarkWorker()), "SetupWorker %s", request.Suite)
+	step.Start()
+
+	suite, err := w.getSuite(request.Suite)
+	if err != nil {
+		step.Fail(err)
+		return nil, err
+	}
+
+	if setupWorker, ok := suite.(SetupWorker); ok {
+		setupWorker.SetupWorker(newContext(request.Suite, request.Args))
+	}
+
+	step.Complete()
+	return &SuiteResponse{}, nil
+}
+
+// TearDownWorker tears down a benchmark worker
+func (w *Worker) TearDownWorker(ctx context.Context, request *SuiteRequest) (*SuiteResponse, error) {
+	step := logging.NewStep(fmt.Sprintf("%s/%d", request.Suite, getBenchmarkWorker()), "TearDownWorker %s", request.Suite)
+	step.Start()
+
+	suite, err := w.getSuite(request.Suite)
+	if err != nil {
+		step.Fail(err)
+		return nil, err
+	}
+
+	if tearDownWorker, ok := suite.(TearDownWorker); ok {
+		tearDownWorker.TearDownWorker(newContext(request.Suite, request.Args))
+	}
+
+	step.Complete()
+	return &SuiteResponse{}, nil
+}
+
+// SetupBenchmark sets up a benchmark
+func (w *Worker) SetupBenchmark(ctx context.Context, request *BenchmarkRequest) (*BenchmarkResponse, error) {
+	step := logging.NewStep(fmt.Sprintf("%s/%d", request.Suite, getBenchmarkWorker()), "SetupBenchmark %s", request.Benchmark)
+	step.Start()
+
+	suite, err := w.getSuite(request.Suite)
+	if err != nil {
+		step.Fail(err)
+		return nil, err
+	}
+
+	if setupBenchmark, ok := suite.(SetupBenchmark); ok {
+		setupBenchmark.SetupBenchmark(newContext(request.Benchmark, request.Args))
+	}
+
+	step.Complete()
+	return &BenchmarkResponse{}, nil
+}
+
+// TearDownBenchmark tears down a benchmark
+func (w *Worker) TearDownBenchmark(ctx context.Context, request *BenchmarkRequest) (*BenchmarkResponse, error) {
+	step := logging.NewStep(fmt.Sprintf("%s/%d", request.Suite, getBenchmarkWorker()), "TearDownBenchmark %s", request.Benchmark)
+	step.Start()
+
+	suite, err := w.getSuite(request.Suite)
+	if err != nil {
+		step.Fail(err)
+		return nil, err
+	}
+
+	if tearDownBenchmark, ok := suite.(TearDownBenchmark); ok {
+		tearDownBenchmark.TearDownBenchmark(newContext(request.Benchmark, request.Args))
+	}
+
+	step.Complete()
+	return &BenchmarkResponse{}, nil
+}
+
+// RunBenchmark runs a benchmark
+func (w *Worker) RunBenchmark(ctx context.Context, request *RunRequest) (*RunResponse, error) {
+	step := logging.NewStep(fmt.Sprintf("%s/%d", request.Suite, getBenchmarkWorker()), "RunBenchmark %s", request.Benchmark)
+	step.Start()
+
+	suite, err := w.getSuite(request.Suite)
+	if err != nil {
+		step.Fail(err)
+		return nil, err
+	}
+
+	methods := reflect.TypeOf(suite)
+	method, ok := methods.MethodByName(request.Benchmark)
+	if !ok {
+		err = fmt.Errorf("unknown benchmark method %s", request.Benchmark)
+		step.Fail(err)
+		return nil, err
+	}
+
+	context := newContext(request.Benchmark, request.Args)
+	b := newBenchmark(request.Benchmark, int(request.Requests), int(request.Parallelism), context)
+	method.Func.Call([]reflect.Value{reflect.ValueOf(suite), reflect.ValueOf(b)})
+
+	step.Complete()
+	return b.getResult(), nil
+}
+
+// benchmarkFilter filters benchmark method names
+func benchmarkFilter(name string) (bool, error) {
+	if ok, _ := regexp.MatchString("^Benchmark", name); !ok {
+		return false, nil
+	}
+	return true, nil
 }

--- a/pkg/onit/cli/benchmark.go
+++ b/pkg/onit/cli/benchmark.go
@@ -42,6 +42,8 @@ func getBenchCommand() *cobra.Command {
 	cmd.Flags().StringToStringP("arg", "a", map[string]string{}, "a mapping of named benchmark arguments")
 	cmd.Flags().Duration("timeout", 10*time.Minute, "benchmark timeout")
 	cmd.Flags().Bool("no-teardown", false, "do not tear down clusters following tests")
+
+	_ = cmd.MarkFlagRequired("image")
 	return cmd
 }
 

--- a/pkg/onit/cli/test.go
+++ b/pkg/onit/cli/test.go
@@ -38,6 +38,8 @@ func getTestCommand() *cobra.Command {
 	cmd.Flags().StringP("test", "t", "", "the name of the test method to run")
 	cmd.Flags().Duration("timeout", 10*time.Minute, "test timeout")
 	cmd.Flags().Bool("no-teardown", false, "do not tear down clusters following tests")
+
+	_ = cmd.MarkFlagRequired("image")
 	return cmd
 }
 


### PR DESCRIPTION
This PR fixes bugs in the `benchmark` command to ensure benchmark coordinators can deploy and manage multiple workers. When `onit benchmark` is run, the benchmark coordinator deploys a configurable number of worker pods to run the benchmark. Worker pods implement a gRPC API that allows the coordinator to setup the test suite, setup workers, setup individual benchmarks, and run benchmarks remotely to parallelize work.

```
onit run benchmark --image onosproject/onos-benchmarks:latest --suite grpc --requests 10000 --workers 3
```