### PR TITLE
change order of jobs in onos-tests to build docs before integration t…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,11 @@ jobs:
     - stage: tests
       script: make coverage
 
+    - stage: docs build
+      if: type != pull_request
+      script:
+        - sh build/bin/trigger-docs-travis $TRAVIS_ACCESS_TOKEN
+
     - stage: integration-tests
       if: type != pull_request
       notifications:
@@ -51,10 +56,6 @@ jobs:
         - export KUBECONFIG="$(kind get kubeconfig-path)"
         - kind create cluster
         - make integration
-    - stage: docs build
-      if: type != pull_request
-      script:
-          - sh build/bin/trigger-docs-travis $TRAVIS_ACCESS_TOKEN
     - stage: push images
       if: type != pull_request
       script:


### PR DESCRIPTION
When integration tests fail, the Travis does not execute  the job which is related to building docs. In this case, if someone updates the docs, the website won't get updated. So it would be better to change the order of travis jobs to build docs first before running integration tests to avoid such dependency.  However, it is possible to run it parallel as well but for now I think changing the order should be enough. 