### PR TITLE
Minimize service, deployment, node arguments passed to their constructors

### DIFF
--- a/pkg/onit/cluster/app.go
+++ b/pkg/onit/cluster/app.go
@@ -28,8 +28,13 @@ var appSecrets = map[string]string{
 func newApp(cluster *Cluster, name string) *App {
 	labels := getLabels(appType)
 	labels[appLabel] = name
+	service := newService(cluster)
+	service.SetSecrets(appSecrets)
+	service.SetName(name)
+	service.SetLabels(labels)
+
 	return &App{
-		Service: newService(cluster, name, []Port{}, labels, "", appSecrets, []string{}),
+		Service: service,
 	}
 }
 

--- a/pkg/onit/cluster/atomix.go
+++ b/pkg/onit/cluster/atomix.go
@@ -15,13 +15,14 @@
 package cluster
 
 import (
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 const (
@@ -32,8 +33,13 @@ const (
 )
 
 func newAtomix(cluster *Cluster) *Atomix {
+	deployment := newDeployment(cluster)
+	deployment.SetLabels(getLabels(atomixType))
+	deployment.SetImage(atomixImage)
+	deployment.SetName(atomixService)
+
 	return &Atomix{
-		Deployment: newDeployment(cluster, atomixService, getLabels(atomixType), atomixImage),
+		Deployment: deployment,
 	}
 }
 

--- a/pkg/onit/cluster/cli.go
+++ b/pkg/onit/cluster/cli.go
@@ -16,11 +16,12 @@ package cluster
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 const (
@@ -30,8 +31,13 @@ const (
 )
 
 func newCLI(cluster *Cluster) *CLI {
+	deployment := newDeployment(cluster)
+	deployment.SetImage(cliImage)
+	deployment.SetLabels(getLabels(cliType))
+	deployment.SetName(cliService)
+
 	return &CLI{
-		Deployment: newDeployment(cluster, cliService, getLabels(cliType), cliImage),
+		Deployment: deployment,
 	}
 }
 

--- a/pkg/onit/cluster/config.go
+++ b/pkg/onit/cluster/config.go
@@ -38,8 +38,17 @@ var configArgs = []string{
 }
 
 func newConfig(cluster *Cluster) *Config {
+	service := newService(cluster)
+	ports := []Port{{Name: "grpc", Port: configPort}}
+	service.SetArgs(configArgs...)
+	service.SetSecrets(configSecrets)
+	service.SetPorts(ports)
+	service.SetLabels(getLabels(configType))
+	service.SetImage(configImage)
+	service.SetName(configService)
+
 	return &Config{
-		Service: newService(cluster, configService, []Port{{Name: "grpc", Port: configPort}}, getLabels(configType), configImage, configSecrets, configArgs),
+		Service: service,
 	}
 }
 

--- a/pkg/onit/cluster/deployment.go
+++ b/pkg/onit/cluster/deployment.go
@@ -92,11 +92,19 @@ func (d *Deployment) Node(name string) (*Node, error) {
 	for _, container := range pod.Spec.Containers {
 		for _, port := range container.Ports {
 			if port.Name == apiPort {
-				return newNode(d.cluster, name, int(port.ContainerPort), container.Image), nil
+				node := newNode(d.cluster)
+				node.SetName(name)
+				node.SetPort(int(port.ContainerPort))
+				node.SetImage(container.Image)
+				return node, nil
 			}
 		}
 	}
-	return newNode(d.cluster, name, 0, ""), nil
+	node := newNode(d.cluster)
+	node.SetName(name)
+	node.SetPort(0)
+
+	return node, nil
 }
 
 // Nodes returns a list of nodes in the service

--- a/pkg/onit/cluster/deployment.go
+++ b/pkg/onit/cluster/deployment.go
@@ -16,20 +16,18 @@ package cluster
 
 import (
 	"errors"
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 const apiPort = "api"
 
-func newDeployment(cluster *Cluster, name string, labels map[string]string, image string) *Deployment {
+func newDeployment(cluster *Cluster) *Deployment {
 	return &Deployment{
 		client:     cluster.client,
 		cluster:    cluster,
-		name:       name,
-		labels:     labels,
-		image:      image,
 		pullPolicy: corev1.PullIfNotPresent,
 	}
 }
@@ -42,6 +40,21 @@ type Deployment struct {
 	labels     map[string]string
 	image      string
 	pullPolicy corev1.PullPolicy
+}
+
+// SetLabels sets the labels for the service
+func (d *Deployment) SetLabels(labels map[string]string) {
+	d.labels = labels
+}
+
+// SetCluster sets the cluster for the service
+func (d *Deployment) SetCluster(cluster *Cluster) {
+	d.cluster = cluster
+}
+
+// SetName sets the name for the service
+func (d *Deployment) SetName(name string) {
+	d.name = name
 }
 
 // Name returns the deployment name

--- a/pkg/onit/cluster/network.go
+++ b/pkg/onit/cluster/network.go
@@ -60,7 +60,7 @@ func newNetwork(cluster *Cluster, name string) *Network {
 	node.SetName(name)
 	node.SetPort(0)
 	return &Network{
-		Node:          newNode(cluster),
+		Node:          node,
 		add:           true,
 		deviceType:    networkDeviceType,
 		deviceVersion: networkDeviceVersion,

--- a/pkg/onit/cluster/network.go
+++ b/pkg/onit/cluster/network.go
@@ -17,6 +17,8 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	"github.com/onosproject/onos-topo/api/device"
 	"google.golang.org/grpc"
@@ -24,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"time"
 )
 
 const (
@@ -54,8 +55,12 @@ func (d TopoType) String() string {
 }
 
 func newNetwork(cluster *Cluster, name string) *Network {
+	node := newNode(cluster)
+	node.SetImage(networkImage)
+	node.SetName(name)
+	node.SetPort(0)
 	return &Network{
-		Node:          newNode(cluster, name, 0, networkImage),
+		Node:          newNode(cluster),
 		add:           true,
 		deviceType:    networkDeviceType,
 		deviceVersion: networkDeviceVersion,
@@ -86,7 +91,10 @@ func (s *Network) Devices() ([]*Node, error) {
 
 	devices := make([]*Node, len(services.Items))
 	for i, service := range services.Items {
-		devices[i] = newNode(s.cluster, service.Name, stratumPort, "")
+		node := newNode(s.cluster)
+		node.SetName(service.Name)
+		node.SetPort(stratumPort)
+		devices[i] = node
 	}
 	return devices, nil
 }

--- a/pkg/onit/cluster/node.go
+++ b/pkg/onit/cluster/node.go
@@ -64,6 +64,7 @@ func (n *Node) SetPort(port int) {
 	n.port = port
 }
 
+// Port returns the node port
 func (n *Node) Port() int {
 	return n.port
 }

--- a/pkg/onit/cluster/node.go
+++ b/pkg/onit/cluster/node.go
@@ -19,6 +19,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	corev1 "k8s.io/api/core/v1"
@@ -26,17 +29,12 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 	executil "k8s.io/client-go/util/exec"
-	"strings"
-	"time"
 )
 
-func newNode(cluster *Cluster, name string, port int, image string) *Node {
+func newNode(cluster *Cluster) *Node {
 	return &Node{
 		client:     cluster.client,
 		cluster:    cluster,
-		name:       name,
-		port:       port,
-		image:      image,
 		pullPolicy: corev1.PullIfNotPresent,
 	}
 }
@@ -59,6 +57,15 @@ func (n *Node) Name() string {
 // SetName sets the node name
 func (n *Node) SetName(name string) {
 	n.name = name
+}
+
+// SetPort sets the node port
+func (n *Node) SetPort(port int) {
+	n.port = port
+}
+
+func (n *Node) Port() int {
+	return n.port
 }
 
 // Address returns the service address

--- a/pkg/onit/cluster/partition.go
+++ b/pkg/onit/cluster/partition.go
@@ -26,8 +26,12 @@ func newPartition(cluster *Cluster, name string) *Partition {
 	labels := getLabels(partitionType)
 	labels[groupLabel] = name[:strings.LastIndex(name, "-")]
 	labels[partitionLabel] = name[strings.LastIndex(name, "-")+1:]
+	deployment := newDeployment(cluster)
+	deployment.SetName(name)
+	deployment.SetLabels(labels)
+
 	return &Partition{
-		Deployment: newDeployment(cluster, name, labels, ""),
+		Deployment: deployment,
 	}
 }
 

--- a/pkg/onit/cluster/service.go
+++ b/pkg/onit/cluster/service.go
@@ -17,6 +17,10 @@ package cluster
 import (
 	"crypto/tls"
 	"fmt"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -24,18 +28,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"path"
-	"strings"
-	"time"
 )
 
-func newService(cluster *Cluster, name string, ports []Port, labels map[string]string, image string, secrets map[string]string, args []string) *Service {
+func newService(cluster *Cluster) *Service {
 	return &Service{
-		Deployment: newDeployment(cluster, name, labels, image),
-		ports:      ports,
-		secrets:    secrets,
+		Deployment: newDeployment(cluster),
 		env:        make(map[string]string),
-		args:       args,
 	}
 }
 
@@ -56,11 +54,6 @@ type Service struct {
 	secrets    map[string]string
 	env        map[string]string
 	args       []string
-}
-
-// SetName sets the service name
-func (s *Service) SetName(name string) {
-	s.name = name
 }
 
 // Ports returns the service ports

--- a/pkg/onit/cluster/simulator.go
+++ b/pkg/onit/cluster/simulator.go
@@ -137,7 +137,7 @@ func newSimulator(cluster *Cluster, name string) *Simulator {
 	node.SetImage(simulatorImage)
 	node.SetPort(11161)
 	return &Simulator{
-		Node:          newNode(cluster),
+		Node:          node,
 		add:           true,
 		deviceType:    simulatorDeviceType,
 		deviceVersion: simulatorDeviceVersion,

--- a/pkg/onit/cluster/simulator.go
+++ b/pkg/onit/cluster/simulator.go
@@ -18,15 +18,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	"github.com/onosproject/onos-topo/api/device"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"io"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"time"
 )
 
 const (
@@ -131,8 +132,12 @@ const simulatorConfig = `
 `
 
 func newSimulator(cluster *Cluster, name string) *Simulator {
+	node := newNode(cluster)
+	node.SetName(name)
+	node.SetImage(simulatorImage)
+	node.SetPort(11161)
 	return &Simulator{
-		Node:          newNode(cluster, name, 11161, simulatorImage),
+		Node:          newNode(cluster),
 		add:           true,
 		deviceType:    simulatorDeviceType,
 		deviceVersion: simulatorDeviceVersion,

--- a/pkg/onit/cluster/topo.go
+++ b/pkg/onit/cluster/topo.go
@@ -39,8 +39,16 @@ var topoArgs = []string{
 }
 
 func newTopo(cluster *Cluster) *Topo {
+	service := newService(cluster)
+	ports := []Port{{Name: "grpc", Port: topoPort}}
+	service.SetArgs(topoArgs...)
+	service.SetSecrets(topoSecrets)
+	service.SetPorts(ports)
+	service.SetLabels(getLabels(topoType))
+	service.SetImage(topoImage)
+	service.SetName(topoService)
 	return &Topo{
-		Service: newService(cluster, topoService, []Port{{Name: "grpc", Port: topoPort}}, getLabels(topoType), topoImage, topoSecrets, topoArgs),
+		Service: service,
 	}
 }
 


### PR DESCRIPTION
This PR minimized the number of arguments passed to`newService`, `newDeployment`, `newNode` functions. Technically, we just need to pass cluster as an argument to those functions and the rest of parameters can be initialized using `Setter` functions. 

