### PR TITLE
Expose API for not registering a simulator with onos-topo

### DIFF
--- a/pkg/onit/cluster/simulator.go
+++ b/pkg/onit/cluster/simulator.go
@@ -487,6 +487,10 @@ func (s *Simulator) TearDown() error {
 
 // removeDevice removes the device from the topo service
 func (s *Simulator) removeDevice() error {
+	if !s.add {
+		return nil
+	}
+
 	tlsConfig, err := s.Credentials()
 	if err != nil {
 		return err

--- a/pkg/onit/env/simulator.go
+++ b/pkg/onit/env/simulator.go
@@ -48,6 +48,9 @@ type SimulatorSetup interface {
 	// SetDeviceTimeout sets the device timeout
 	SetDeviceTimeout(timeout time.Duration) SimulatorSetup
 
+	// SetAddDevice sets whether to add the device to the topo service
+	SetAddDevice(add bool) SimulatorSetup
+
 	// Add deploys the simulator in the cluster
 	Add() (SimulatorEnv, error)
 
@@ -89,6 +92,11 @@ func (s *clusterSimulatorSetup) SetDeviceVersion(version string) SimulatorSetup 
 
 func (s *clusterSimulatorSetup) SetDeviceTimeout(timeout time.Duration) SimulatorSetup {
 	s.simulator.SetDeviceTimeout(timeout)
+	return s
+}
+
+func (s *clusterSimulatorSetup) SetAddDevice(addDevice bool) SimulatorSetup {
+	s.simulator.SetAddDevice(addDevice)
 	return s
 }
 


### PR DESCRIPTION
This PR exposes the SetAddDevice() API in onit to tests. This allows a test to create a device itself via the topo API