### PR TITLE
Ensure benchmark arguments can be overridden by CLI

### DIFF
--- a/pkg/benchmark/config.go
+++ b/pkg/benchmark/config.go
@@ -16,6 +16,7 @@ package benchmark
 
 import (
 	"fmt"
+	"github.com/onosproject/onos-test/pkg/onit/cluster"
 	corev1 "k8s.io/api/core/v1"
 	"os"
 	"strconv"
@@ -54,6 +55,9 @@ func GetConfigFromEnv() *Config {
 		env[key] = value
 	}
 	args := make(map[string]string)
+	for key, value := range cluster.GetArgs() {
+		args[key] = value
+	}
 	for key, value := range env {
 		if strings.HasPrefix(key, benchmarkArgPrefix) {
 			args[strings.ToLower(key[len(benchmarkArgPrefix):])] = value

--- a/pkg/onit/cluster/args.go
+++ b/pkg/onit/cluster/args.go
@@ -46,6 +46,11 @@ func SetArg(name, value string) {
 	args[name] = value
 }
 
+// GetArgs gets the cluster arguments
+func GetArgs() map[string]string {
+	return args
+}
+
 // GetArg gets the value of an argument
 func GetArg(names ...string) *Arg {
 	return &Arg{


### PR DESCRIPTION
Combines CLI arguments with benchmark arguments to ensure all options can be overridden by benchmark CLI.