### PR TITLE
Simplify test/benchmark arguments and environment variables

### DIFF
--- a/pkg/benchmark/config.go
+++ b/pkg/benchmark/config.go
@@ -17,6 +17,7 @@ package benchmark
 import (
 	"fmt"
 	"github.com/onosproject/onos-test/pkg/onit/cluster"
+	"github.com/onosproject/onos-test/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"os"
 	"strconv"
@@ -37,7 +38,7 @@ const (
 	benchmarkWorkersEnv         = "BENCHMARK_WORKERS"
 	benchmarkParallelismEnv     = "BENCHMARK_PARALLELISM"
 	benchmarkRequestsEnv        = "BENCHMARK_REQUESTS"
-	benchmarkArgPrefix          = "BENCHMARK_ARG_"
+	benchmarkArgsEnv            = "BENCHMARK_ARGS"
 	benchmarkWorkerEnv          = "BENCHMARK_WORKER"
 )
 
@@ -58,10 +59,8 @@ func GetConfigFromEnv() *Config {
 	for key, value := range cluster.GetArgs() {
 		args[key] = value
 	}
-	for key, value := range env {
-		if strings.HasPrefix(key, benchmarkArgPrefix) {
-			args[strings.ToLower(key[len(benchmarkArgPrefix):])] = value
-		}
+	for key, value := range util.SplitMap(os.Getenv(benchmarkArgsEnv)) {
+		args[key] = value
 	}
 	workers, err := strconv.Atoi(os.Getenv(benchmarkWorkersEnv))
 	if err != nil {
@@ -115,9 +114,7 @@ func (c *Config) ToEnv() map[string]string {
 	env[benchmarkWorkersEnv] = fmt.Sprintf("%d", c.Workers)
 	env[benchmarkParallelismEnv] = fmt.Sprintf("%d", c.Parallelism)
 	env[benchmarkRequestsEnv] = fmt.Sprintf("%d", c.Requests)
-	for key, value := range c.Args {
-		env[benchmarkArgPrefix+strings.ToUpper(key)] = value
-	}
+	env[benchmarkArgsEnv] = util.JoinMap(c.Args)
 	return env
 }
 

--- a/pkg/onit/cli/test.go
+++ b/pkg/onit/cli/test.go
@@ -16,11 +16,11 @@ package cli
 
 import (
 	"github.com/onosproject/onos-test/pkg/cluster"
+	onitcluster "github.com/onosproject/onos-test/pkg/onit/cluster"
 	"github.com/onosproject/onos-test/pkg/test"
 	"github.com/onosproject/onos-test/pkg/util/random"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 	"time"
 )
 
@@ -53,18 +53,13 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	pullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
 
-	env := make(map[string]string)
-	for key, value := range sets {
-		env["ONIT_ARG_"+strings.ToUpper(strings.ReplaceAll(key, ".", "_"))] = value
-	}
-
 	config := &test.Config{
 		ID:              random.NewPetName(2),
 		Image:           image,
 		ImagePullPolicy: corev1.PullPolicy(pullPolicy),
 		Suite:           suite,
 		Test:            testName,
-		Env:             env,
+		Env:             onitcluster.GetArgsAsEnv(sets),
 		Timeout:         timeout,
 	}
 

--- a/pkg/onit/cluster/args.go
+++ b/pkg/onit/cluster/args.go
@@ -15,6 +15,7 @@
 package cluster
 
 import (
+	"github.com/onosproject/onos-test/pkg/util"
 	"os"
 	"strconv"
 	"strings"
@@ -22,15 +23,11 @@ import (
 
 var args = make(map[string]string)
 
-const argPrefix = "ONIT_ARG_"
+const argsEnv = "ONIT_ARGS"
 
 func init() {
-	for _, keyval := range os.Environ() {
-		key := keyval[:strings.Index(keyval, "=")]
-		if strings.HasPrefix(key, argPrefix) {
-			value := keyval[strings.Index(keyval, "=")+1:]
-			SetArg(strings.ReplaceAll(strings.ToLower(key[len(argPrefix):]), "_", "."), value)
-		}
+	for key, value := range util.SplitMap(os.Getenv(argsEnv)) {
+		SetArg(key, value)
 	}
 }
 
@@ -56,6 +53,13 @@ func GetArg(names ...string) *Arg {
 	return &Arg{
 		value: args[strings.Join(names, ".")],
 	}
+}
+
+// GetArgsAsEnv returns the given arguments as an environment variable map
+func GetArgsAsEnv(args map[string]string) map[string]string {
+	env := make(map[string]string)
+	env[argsEnv] = util.JoinMap(args)
+	return env
 }
 
 // Arg is a cluster argument

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -27,7 +27,7 @@ func SplitMap(value string) map[string]string {
 	values := strings.Split(value, entrySep)
 	pairs := make(map[string]string)
 	for _, pair := range values {
-		if strings.Index(pair, keyValueSep) != -1 {
+		if strings.Contains(pair, keyValueSep) {
 			key := pair[:strings.Index(pair, keyValueSep)]
 			value := pair[strings.Index(pair, keyValueSep)+1:]
 			pairs[key] = value

--- a/pkg/util/env.go
+++ b/pkg/util/env.go
@@ -1,0 +1,46 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+const keyValueSep = "="
+const entrySep = ","
+
+// SplitMap splits the given string into key-value pairs
+func SplitMap(value string) map[string]string {
+	values := strings.Split(value, entrySep)
+	pairs := make(map[string]string)
+	for _, pair := range values {
+		if strings.Index(pair, keyValueSep) != -1 {
+			key := pair[:strings.Index(pair, keyValueSep)]
+			value := pair[strings.Index(pair, keyValueSep)+1:]
+			pairs[key] = value
+		}
+	}
+	return pairs
+}
+
+// JoinMap joins the given map of key-value pairs into a single string
+func JoinMap(pairs map[string]string) string {
+	values := make([]string, 0, len(pairs))
+	for key, value := range pairs {
+		values = append(values, fmt.Sprintf("%s%s%s", key, keyValueSep, value))
+	}
+	return strings.Join(values, entrySep)
+}


### PR DESCRIPTION
This PR simplifies the environment variables used to pass overrides and arguments to tests and benchmarks. A single environment variable containing `pairs=of,keys=values` is used to pass cluster overrides and benchmark arguments into tests.