### PR TITLE
Seperate integration test jobs for each subsystem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,23 @@ jobs:
         # Set KUBECONFIG environment variable
         - export KUBECONFIG="$(kind get kubeconfig-path)"
         - kind create cluster
-        - build/bin/run-integration-tests
+        - build/bin/run-integration-tests onos-topo
+    - # stage name not required, will continue to use `integration-tests`
+      if: type != pull_request
+      script:
+        # Download and install kubectl
+        - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+        # Download and install KinD
+        - GO111MODULE=on go get sigs.k8s.io/kind
+        - git checkout go.mod go.sum
+        - GO111MODULE=on go get github.com/onosproject/onos-test/cmd/onit
+        - git checkout go.mod go.sum
+
+        # Set KUBECONFIG environment variable
+        - export KUBECONFIG="$(kind get kubeconfig-path)"
+        - kind create cluster
+        - build/bin/run-integration-tests onos-config
 
     - stage: push images
       if: type != pull_request

--- a/build/bin/run-integration-tests
+++ b/build/bin/run-integration-tests
@@ -4,18 +4,34 @@
 
 set -e
 
-# onos-topo
-pushd ..
-git clone https://github.com/onosproject/onos-topo.git
-cd onos-topo
-make kind
-onit test --image onosproject/onos-topo-tests:latest --suite topo
-popd
+if [ -z $1 ]
+then
+  testSuite="*** Unknown Test Suite ***"
+elif [ -n $1 ]
+then
+# otherwise make first arg as a rental
+  testSuite=$1
+fi
 
-# onos-config
-pushd ..
-git clone https://github.com/onosproject/onos-config.git
-cd onos-config
-make kind
-onit test --image onosproject/onos-config-tests:latest --suite gnmi
-popd
+case "$testSuite" in
+"onos-topo")
+     # onos-topo
+     pushd ..
+     git clone https://github.com/onosproject/onos-topo.git
+     cd onos-topo
+     make kind
+     onit test --image onosproject/onos-topo-tests:latest --suite topo
+     popd;;
+
+"onos-config")
+    # onos-config
+    pushd ..
+    git clone https://github.com/onosproject/onos-config.git
+    cd onos-config
+    make kind
+    onit test --image onosproject/onos-config-tests:latest --suite gnmi
+    popd;;
+*) echo "You have failed to specify test suite."
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This PR is opened to separate integration tests jobs from each other (i.e. onos-topo tests job and onos-config tests job) and run them in parallel. It has the following advantages:
1- Since integration tests for each subsystem can be executed independent of each other, it would be better to run each as a separate Travis job which consequently reduces the Travis response time
2- In addition, It allows us to easily detect which subsystem's tests are failing without going through the logs. 

P.S. At the moment, since onos-topo has just one test, I think the response time won't be reduced significantly. 
