### PR TITLE
Add onit get history commands

### DIFF
--- a/pkg/cluster/runner.go
+++ b/pkg/cluster/runner.go
@@ -17,6 +17,9 @@ package cluster
 import (
 	"bufio"
 	"errors"
+	"os"
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/kube"
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	batchv1 "k8s.io/api/batch/v1"
@@ -25,8 +28,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"os"
-	"time"
 )
 
 const namespace = "kube-test"
@@ -39,6 +40,7 @@ type Job struct {
 	Args            []string
 	Env             map[string]string
 	Timeout         time.Duration
+	Type            string
 }
 
 // NewRunner returns a new test job runner
@@ -336,7 +338,8 @@ func (r *Runner) createJob(job *Job) error {
 			Name:      job.ID,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				"job": job.ID,
+				"job":  job.ID,
+				"type": job.Type,
 			},
 		},
 		Spec: batchv1.JobSpec{
@@ -346,7 +349,8 @@ func (r *Runner) createJob(job *Job) error {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"job": job.ID,
+						"job":  job.ID,
+						"type": job.Type,
 					},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/onit/cli/benchmark.go
+++ b/pkg/onit/cli/benchmark.go
@@ -15,13 +15,14 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/onosproject/onos-test/pkg/benchmark"
 	"github.com/onosproject/onos-test/pkg/cluster"
 	onitcluster "github.com/onosproject/onos-test/pkg/onit/cluster"
 	"github.com/onosproject/onos-test/pkg/util/random"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	"time"
 )
 
 func getBenchCommand() *cobra.Command {
@@ -93,6 +94,7 @@ func runBenchCommand(cmd *cobra.Command, _ []string) error {
 		ImagePullPolicy: pullPolicy,
 		Env:             config.ToEnv(),
 		Timeout:         timeout,
+		Type:            "benchmark",
 	}
 
 	// Create a job runner and run the benchmark job

--- a/pkg/onit/cli/get.go
+++ b/pkg/onit/cli/get.go
@@ -76,7 +76,9 @@ func runGetTestCommand(cmd *cobra.Command, _ []string) error {
 	}
 
 	env := env.New(kubeAPI)
-	tests := env.History().ListTests()
+	tests := env.History().GetTestsMap()
+	test := tests[getName(cmd)]
+	printTest(test)
 	return nil
 }
 
@@ -108,6 +110,16 @@ func printBenchmarks(jobs []oc.JobInfo) {
 		fmt.Fprintln(w, job.GetJobName(), "\t", job.GetJobStatus(), "\t", job.GetJobType(), "\t", job.GetJobImage(),
 			"\t", job.GetEnvVar()["BENCHMARK_SUITE"], "\t", job.GetEnvVar()["BENCHMARK_NAME"])
 	}
+	w.Flush()
+}
+
+func printTest(job oc.JobInfo) {
+	w := new(tabwriter.Writer)
+	w.Init(os.Stdout, 0, 0, 0, ' ', tabwriter.Debug|tabwriter.AlignRight)
+	fmt.Fprintln(w, "Job Name\tStatus\tType\tImage\tTest Suite\tTest Name")
+	fmt.Fprintln(w, job.GetJobName(), "\t", job.GetJobStatus(), "\t", job.GetJobType(), "\t", job.GetJobImage(),
+		"\t", job.GetEnvVar()["TEST_SUITE"], "\t", job.GetEnvVar()["TEST_NAME"])
+
 	w.Flush()
 }
 

--- a/pkg/onit/cli/test.go
+++ b/pkg/onit/cli/test.go
@@ -83,6 +83,7 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 		ImagePullPolicy: corev1.PullPolicy(pullPolicy),
 		Env:             config.ToEnv(),
 		Timeout:         timeout,
+		Type:            "test",
 	}
 
 	// Create a job runner and run the test job

--- a/pkg/onit/cluster/client.go
+++ b/pkg/onit/cluster/client.go
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	atomixcontroller "github.com/atomix/kubernetes-controller/pkg/client/v1beta1/clientset/versioned"
+	v1 "k8s.io/api/core/v1"
 	apiextension "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -30,6 +31,16 @@ type client struct {
 	kubeClient       *kubernetes.Clientset
 	atomixClient     *atomixcontroller.Clientset
 	extensionsClient *apiextension.Clientset
+}
+
+func (c *client) getPods(matchLabels map[string]string, namespace string) *v1.PodList {
+	labelSelector := metav1.LabelSelector{MatchLabels: matchLabels}
+	pods, err := c.kubeClient.CoreV1().Pods(namespace).List(metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String()})
+	if err != nil {
+		panic(err)
+	}
+	return pods
 }
 
 func (c *client) listPods(matchLabels map[string]string) []string {

--- a/pkg/onit/cluster/cluster.go
+++ b/pkg/onit/cluster/cluster.go
@@ -42,6 +42,7 @@ func New(kube kube.API) *Cluster {
 	cluster.apps = newApps(cluster)
 	cluster.simulators = newSimulators(cluster)
 	cluster.networks = newNetworks(cluster)
+	cluster.history = newHistory(cluster)
 	return cluster
 }
 
@@ -57,6 +58,7 @@ type Cluster struct {
 	apps       *Apps
 	simulators *Simulators
 	networks   *Networks
+	history    *History
 }
 
 // Atomix returns the Atomix service
@@ -102,4 +104,9 @@ func (c *Cluster) Simulators() *Simulators {
 // Networks returns the cluster networks
 func (c *Cluster) Networks() *Networks {
 	return c.networks
+}
+
+// History returns the cluster history
+func (c *Cluster) History() *History {
+	return c.history
 }

--- a/pkg/onit/cluster/history.go
+++ b/pkg/onit/cluster/history.go
@@ -1,0 +1,147 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+func newHistory(cluster *Cluster) *History {
+	return &History{
+		client:  cluster.client,
+		cluster: cluster,
+	}
+}
+
+// New returns a new history
+func (h *History) New() *History {
+	return newHistory(h.cluster)
+}
+
+// History provides methods for retrieving history of tests and benchmarks
+type History struct {
+	*client
+	cluster *Cluster
+}
+
+// JobInfo k8s job info
+type JobInfo struct {
+	jobName string
+	status  string
+	jobType string
+	image   string
+	envVar  map[string]string
+}
+
+// Status job status
+type Status int
+
+const (
+	// Succeeded status
+	Succeeded Status = iota
+	// Failed status
+	Failed
+	// Running status
+	Running
+	// Pending status
+	Pending
+	// Unknown status
+	Unknown
+)
+
+func (s Status) String() string {
+	return [...]string{"Succeeded", "Failed", "Running", "Pending", "Unknown"}[s]
+}
+
+// GetEnvVar gets the job environment variables
+func (j *JobInfo) GetEnvVar() map[string]string {
+	return j.envVar
+}
+
+// GetJobImage gets job image
+func (j *JobInfo) GetJobImage() string {
+	return j.image
+}
+
+// GetJobName gets job name
+func (j *JobInfo) GetJobName() string {
+	return j.jobName
+}
+
+// GetJobStatus gets job status
+func (j *JobInfo) GetJobStatus() string {
+	return j.status
+}
+
+// GetJobType gets job type
+func (j *JobInfo) GetJobType() string {
+	return j.jobType
+}
+
+// getJobs gets list of all jobs based on a given jobType
+func (h *History) getJobs(jobType string) []JobInfo {
+	pods := h.getPods(getLabels(jobType), "kube-test")
+	var jobs []JobInfo
+
+	for _, pod := range pods.Items {
+		status := ""
+		switch pod.Status.Phase {
+		case v1.PodSucceeded:
+			status = Succeeded.String()
+		case v1.PodRunning:
+			status = Running.String()
+
+		case v1.PodFailed:
+			status = Failed.String()
+
+		case v1.PodPending:
+			status = Pending.String()
+
+		case v1.PodUnknown:
+			status = Unknown.String()
+
+		}
+		envVars := pod.Spec.Containers[0].Env
+		envVarMap := make(map[string]string, len(envVars))
+		for _, envVar := range envVars {
+			envVarMap[envVar.Name] = envVar.Value
+		}
+
+		job := JobInfo{
+			jobName: pod.Name,
+			status:  status,
+			jobType: pod.Labels["type"],
+			image:   pod.Spec.Containers[0].Image,
+			envVar:  envVarMap,
+		}
+		jobs = append(jobs, job)
+
+	}
+
+	return jobs
+
+}
+
+// ListTests gets list of all tests
+func (h *History) ListTests() []JobInfo {
+	testJobs := h.getJobs("test")
+	return testJobs
+}
+
+// ListBenchmarks gets list of all benchmarks
+func (h *History) ListBenchmarks() []JobInfo {
+	benchJobs := h.getJobs("benchmark")
+	return benchJobs
+}

--- a/pkg/onit/cluster/history.go
+++ b/pkg/onit/cluster/history.go
@@ -91,9 +91,10 @@ func (j *JobInfo) GetJobType() string {
 }
 
 // getJobs gets list of all jobs based on a given jobType
-func (h *History) getJobs(jobType string) []JobInfo {
+func (h *History) getJobs(jobType string) ([]JobInfo, map[string]JobInfo) {
 	pods := h.getPods(getLabels(jobType), "kube-test")
 	var jobs []JobInfo
+	jobsMap := make(map[string]JobInfo, len(pods.Items))
 
 	for _, pod := range pods.Items {
 		status := ""
@@ -127,21 +128,34 @@ func (h *History) getJobs(jobType string) []JobInfo {
 			envVar:  envVarMap,
 		}
 		jobs = append(jobs, job)
+		jobsMap[job.jobName] = job
 
 	}
 
-	return jobs
+	return jobs, jobsMap
 
+}
+
+// GetTestsMap gets a map of test jobs
+func (h *History) GetTestsMap() map[string]JobInfo {
+	_, mapTests := h.getJobs("test")
+	return mapTests
+}
+
+// GetBenchmarksMap gets a maps of benchmarks
+func (h *History) GetBenchmarksMap() map[string]JobInfo {
+	_, mapBenchmarks := h.getJobs("benchmark")
+	return mapBenchmarks
 }
 
 // ListTests gets list of all tests
 func (h *History) ListTests() []JobInfo {
-	testJobs := h.getJobs("test")
+	testJobs, _ := h.getJobs("test")
 	return testJobs
 }
 
 // ListBenchmarks gets list of all benchmarks
 func (h *History) ListBenchmarks() []JobInfo {
-	benchJobs := h.getJobs("benchmark")
+	benchJobs, _ := h.getJobs("benchmark")
 	return benchJobs
 }

--- a/pkg/onit/cluster/history.go
+++ b/pkg/onit/cluster/history.go
@@ -138,14 +138,14 @@ func (h *History) getJobs(jobType string) ([]JobInfo, map[string]JobInfo) {
 
 // GetTestsMap gets a map of test jobs
 func (h *History) GetTestsMap() map[string]JobInfo {
-	_, mapTests := h.getJobs("test")
-	return mapTests
+	_, testsMap := h.getJobs("test")
+	return testsMap
 }
 
 // GetBenchmarksMap gets a maps of benchmarks
 func (h *History) GetBenchmarksMap() map[string]JobInfo {
-	_, mapBenchmarks := h.getJobs("benchmark")
-	return mapBenchmarks
+	_, benchmarksMap := h.getJobs("benchmark")
+	return benchmarksMap
 }
 
 // ListTests gets list of all tests

--- a/pkg/onit/env/env.go
+++ b/pkg/onit/env/env.go
@@ -96,6 +96,11 @@ func Network(name string) NetworkEnv {
 	return getEnv().Network(name)
 }
 
+// History returns the environment for the history
+func History() HistoryEnv {
+	return getEnv().History()
+}
+
 // NewNetwork returns the setup configuration for a new network
 func NewNetwork() NetworkSetup {
 	return getEnv().NewNetwork()
@@ -153,6 +158,9 @@ type ClusterEnv interface {
 
 	// Network returns the environment for a network by name
 	Network(name string) NetworkEnv
+
+	// History returns the environment for the history
+	History() HistoryEnv
 
 	// NewNetwork returns a new NetworkSetup for adding a network to the cluster
 	NewNetwork() NetworkSetup
@@ -253,6 +261,12 @@ func (e *clusterEnv) AddSimulators(simulators ...SimulatorSetup) SimulatorsSetup
 func (e *clusterEnv) Networks() NetworksEnv {
 	return &clusterNetworksEnv{
 		networks: e.cluster.Networks(),
+	}
+}
+
+func (e *clusterEnv) History() HistoryEnv {
+	return &clusterHistoryEnv{
+		history: e.cluster.History(),
 	}
 }
 

--- a/pkg/onit/env/history.go
+++ b/pkg/onit/env/history.go
@@ -1,0 +1,48 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package env
+
+import (
+	"github.com/onosproject/onos-test/pkg/onit/cluster"
+)
+
+// HistoryEnv provides the history environment
+type HistoryEnv interface {
+	// List returns a history of tests and benchmarks
+	List() []cluster.JobInfo
+
+	// ListTests returns a history of tests
+	ListTests() []cluster.JobInfo
+
+	// ListBenchmarks returns a history of benchmarks
+	ListBenchmarks() []cluster.JobInfo
+}
+
+var _ HistoryEnv = &clusterHistoryEnv{}
+
+// clusterNetworksEnv is an implementation of the Networks interface
+type clusterHistoryEnv struct {
+	history *cluster.History
+}
+
+// ListTests gets list of tests
+func (e *clusterHistoryEnv) ListTests() []cluster.JobInfo {
+	return e.history.ListTests()
+}
+
+// ListBenchmarks gets list of benchmarks
+func (e *clusterHistoryEnv) ListBenchmarks() []cluster.JobInfo {
+	return e.history.ListBenchmarks()
+}

--- a/pkg/onit/env/history.go
+++ b/pkg/onit/env/history.go
@@ -20,8 +20,12 @@ import (
 
 // HistoryEnv provides the history environment
 type HistoryEnv interface {
-	// List returns a history of tests and benchmarks
-	List() []cluster.JobInfo
+
+	// GetTestsMap returns a map of tests
+	GetTestsMap() map[string]cluster.JobInfo
+
+	// GetBenchmarksMap returns a map of benchmarks
+	GetBenchmarksMap() map[string]cluster.JobInfo
 
 	// ListTests returns a history of tests
 	ListTests() []cluster.JobInfo
@@ -45,4 +49,14 @@ func (e *clusterHistoryEnv) ListTests() []cluster.JobInfo {
 // ListBenchmarks gets list of benchmarks
 func (e *clusterHistoryEnv) ListBenchmarks() []cluster.JobInfo {
 	return e.history.ListBenchmarks()
+}
+
+// GetTestsMap gets a map of tests
+func (e *clusterHistoryEnv) GetTestsMap() map[string]cluster.JobInfo {
+	return e.history.GetTestsMap()
+}
+
+// GetBenchmarksMap gets a map of benchmarks
+func (e *clusterHistoryEnv) GetBenchmarksMap() map[string]cluster.JobInfo {
+	return e.history.GetBenchmarksMap()
 }


### PR DESCRIPTION
To address issue #212. This PR adds the following command to onit:
1. `onit get tests` that prints the results of all tests in terms of status (e.g. running, failed, succeeded), test image, test suite, test name. 


2. `onit get benchmarks`  that prints the results of all tests in terms of status (e.g. running, failed, succeeded), benchmark image, benchmark suite, benchmark name.  


3. `onit get benchmark  benchmark-job-name` prints the results of a specific benchmark

4. `onit get test test-job-name` prints the results of a specific test. 

Just as an example:
```
             Job Name|     Status|  Type|                                 Image|Test Suite|Test Name
    able-trout-slggd | Succeeded | test | onosproject/onos-config-tests:latest |     gnmi | TestSubscribeOnce
solid-shepherd-vr559 | Succeeded | test | onosproject/onos-config-tests:latest |     gnmi | TestSubscribe
```