### PR TITLE
Add Raft benchmarks and cleanup benchmark API

### DIFF
--- a/benchmark/grpc/grpc_bench.go
+++ b/benchmark/grpc/grpc_bench.go
@@ -53,7 +53,7 @@ func (s *BenchmarkSuite) TearDownBenchmark(c *benchmark.Context) {
 // BenchmarkGRPCRequestReply :: benchmark
 func (s *BenchmarkSuite) BenchmarkGRPCRequestReply(b *benchmark.Benchmark) {
 	params := []benchmark.Param{
-		benchmark.RandomBytes(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
+		benchmark.RandomBytesFromSet(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
 	}
 	client := NewTestServiceClient(s.conn)
 	b.Run(func(value []byte) error {

--- a/benchmark/grpc/grpc_bench.go
+++ b/benchmark/grpc/grpc_bench.go
@@ -17,6 +17,7 @@ package grpc
 import (
 	"context"
 	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-test/pkg/benchmark/params"
 	"github.com/onosproject/onos-test/pkg/onit/setup"
 	"google.golang.org/grpc"
 )
@@ -52,14 +53,11 @@ func (s *BenchmarkSuite) TearDownBenchmark(c *benchmark.Context) {
 
 // BenchmarkGRPCRequestReply :: benchmark
 func (s *BenchmarkSuite) BenchmarkGRPCRequestReply(b *benchmark.Benchmark) {
-	params := []benchmark.Param{
-		benchmark.RandomBytesFromSet(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
-	}
 	client := NewTestServiceClient(s.conn)
 	b.Run(func(value []byte) error {
 		_, err := client.RequestReply(context.Background(), &Message{
 			Value: value,
 		})
 		return err
-	}, params...)
+	}, params.RandomBytes(b.GetArg("value-length").Int(128)))
 }

--- a/benchmark/nopaxos/map.go
+++ b/benchmark/nopaxos/map.go
@@ -58,8 +58,8 @@ func (s *MapBenchmarkSuite) TearDownBenchmark(c *benchmark.Context) {
 // BenchmarkMapPut :: benchmark
 func (s *MapBenchmarkSuite) BenchmarkMapPut(b *benchmark.Benchmark) {
 	params := []benchmark.Param{
-		benchmark.RandomString(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
-		benchmark.RandomBytes(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
+		benchmark.RandomStringFromSet(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
+		benchmark.RandomBytesFromSet(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
 	}
 	b.Run(func(key string, value []byte) error {
 		_, err := s._map.Put(context.Background(), key, value)
@@ -70,7 +70,7 @@ func (s *MapBenchmarkSuite) BenchmarkMapPut(b *benchmark.Benchmark) {
 // BenchmarkMapGet :: benchmark
 func (s *MapBenchmarkSuite) BenchmarkMapGet(b *benchmark.Benchmark) {
 	params := []benchmark.Param{
-		benchmark.RandomString(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
+		benchmark.RandomStringFromSet(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
 	}
 	b.Run(func(key string) error {
 		_, err := s._map.Get(context.Background(), key)

--- a/benchmark/nopaxos/map.go
+++ b/benchmark/nopaxos/map.go
@@ -30,10 +30,7 @@ type MapBenchmarkSuite struct {
 
 // SetupSuite :: benchmark
 func (s *MapBenchmarkSuite) SetupSuite(c *benchmark.Context) {
-	setup.Partitions("nopaxos").
-		NOPaxos().
-		SetPartitions(c.GetArg("partitions").Int(1)).
-		SetReplicasPerPartition(c.GetArg("replicas").Int(1))
+	setup.Partitions("nopaxos").NOPaxos()
 	setup.SetupOrDie()
 }
 

--- a/benchmark/nopaxos/map.go
+++ b/benchmark/nopaxos/map.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"github.com/atomix/atomix-go-client/pkg/client/map"
 	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-test/pkg/benchmark/params"
 	"github.com/onosproject/onos-test/pkg/onit/env"
 	"github.com/onosproject/onos-test/pkg/onit/setup"
 )
@@ -54,23 +55,27 @@ func (s *MapBenchmarkSuite) TearDownBenchmark(c *benchmark.Context) {
 
 // BenchmarkMapPut :: benchmark
 func (s *MapBenchmarkSuite) BenchmarkMapPut(b *benchmark.Benchmark) {
-	params := []benchmark.Param{
-		benchmark.RandomStringFromSet(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
-		benchmark.RandomBytesFromSet(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
-	}
 	b.Run(func(key string, value []byte) error {
 		_, err := s._map.Put(context.Background(), key, value)
 		return err
-	}, params...)
+	},
+		params.RandomChoice(
+			params.SetOf(
+				params.RandomString(b.GetArg("key-length").Int(8)),
+				b.GetArg("key-count").Int(1000))),
+		params.RandomChoice(
+			params.SetOf(
+				params.RandomBytes(b.GetArg("value-length").Int(128)),
+				b.GetArg("value-count").Int(1))))
 }
 
 // BenchmarkMapGet :: benchmark
 func (s *MapBenchmarkSuite) BenchmarkMapGet(b *benchmark.Benchmark) {
-	params := []benchmark.Param{
-		benchmark.RandomStringFromSet(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
-	}
 	b.Run(func(key string) error {
 		_, err := s._map.Get(context.Background(), key)
 		return err
-	}, params...)
+	}, params.RandomChoice(
+		params.SetOf(
+			params.RandomString(b.GetArg("key-length").Int(8)),
+			b.GetArg("key-count").Int(1000))))
 }

--- a/benchmark/raft/map.go
+++ b/benchmark/raft/map.go
@@ -83,6 +83,7 @@ func (s *MapBenchmarkSuite) BenchmarkMapGet(b *benchmark.Benchmark) {
 			b.GetArg("key-count").Int(1000))))
 }
 
+// SetupBenchmarkMapEvent sets up the map event benchmark
 func (s *MapBenchmarkSuite) SetupBenchmarkMapEvent(c *benchmark.Context) {
 	watchCh := make(chan *_map.Event)
 	if err := s._map.Watch(context.Background(), watchCh); err != nil {
@@ -91,6 +92,7 @@ func (s *MapBenchmarkSuite) SetupBenchmarkMapEvent(c *benchmark.Context) {
 	s.watchCh = watchCh
 }
 
+// TearDownBenchmarkMapEvent tears down the map event benchmark
 func (s *MapBenchmarkSuite) TearDownBenchmarkMapEvent(c *benchmark.Context) {
 	s.watchCh = nil
 }

--- a/benchmark/raft/map.go
+++ b/benchmark/raft/map.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"github.com/atomix/atomix-go-client/pkg/client/map"
 	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-test/pkg/benchmark/params"
 	"github.com/onosproject/onos-test/pkg/onit/env"
 	"github.com/onosproject/onos-test/pkg/onit/setup"
 	"time"
@@ -57,25 +58,29 @@ func (s *MapBenchmarkSuite) TearDownBenchmark(c *benchmark.Context) {
 
 // BenchmarkMapPut :: benchmark
 func (s *MapBenchmarkSuite) BenchmarkMapPut(b *benchmark.Benchmark) {
-	params := []benchmark.Param{
-		benchmark.RandomStringFromSet(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
-		benchmark.RandomBytesFromSet(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
-	}
 	b.Run(func(key string, value []byte) error {
 		_, err := s._map.Put(context.Background(), key, value)
 		return err
-	}, params...)
+	},
+		params.RandomChoice(
+			params.SetOf(
+				params.RandomString(b.GetArg("key-length").Int(8)),
+				b.GetArg("key-count").Int(1000))),
+		params.RandomChoice(
+			params.SetOf(
+				params.RandomBytes(b.GetArg("value-length").Int(128)),
+				b.GetArg("value-count").Int(1))))
 }
 
 // BenchmarkMapGet :: benchmark
 func (s *MapBenchmarkSuite) BenchmarkMapGet(b *benchmark.Benchmark) {
-	params := []benchmark.Param{
-		benchmark.RandomStringFromSet(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
-	}
 	b.Run(func(key string) error {
 		_, err := s._map.Get(context.Background(), key)
 		return err
-	}, params...)
+	}, params.RandomChoice(
+		params.SetOf(
+			params.RandomString(b.GetArg("key-length").Int(8)),
+			b.GetArg("key-count").Int(1000))))
 }
 
 func (s *MapBenchmarkSuite) SetupBenchmarkMapEvent(c *benchmark.Context) {
@@ -92,10 +97,6 @@ func (s *MapBenchmarkSuite) TearDownBenchmarkMapEvent(c *benchmark.Context) {
 
 // BenchmarkMapEvent :: benchmark
 func (s *MapBenchmarkSuite) BenchmarkMapEvent(b *benchmark.Benchmark) {
-	params := []benchmark.Param{
-		benchmark.RandomString(b.GetArg("key-length").Int(8)),
-		benchmark.RandomBytes(b.GetArg("value-length").Int(128)),
-	}
 	b.Run(func(key string, value []byte) error {
 		_, err := s._map.Put(context.Background(), key, value)
 		select {
@@ -104,5 +105,7 @@ func (s *MapBenchmarkSuite) BenchmarkMapEvent(b *benchmark.Benchmark) {
 		case <-time.After(10 * time.Second):
 			return errors.New("event timeout")
 		}
-	}, params...)
+	},
+		params.RandomString(b.GetArg("key-length").Int(8)),
+		params.RandomBytes(b.GetArg("value-length").Int(128)))
 }

--- a/benchmark/raft/map.go
+++ b/benchmark/raft/map.go
@@ -1,0 +1,76 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raft
+
+import (
+	"context"
+	"github.com/atomix/atomix-go-client/pkg/client/map"
+	"github.com/onosproject/onos-test/pkg/benchmark"
+	"github.com/onosproject/onos-test/pkg/onit/env"
+	"github.com/onosproject/onos-test/pkg/onit/setup"
+)
+
+// MapBenchmarkSuite :: benchmark
+type MapBenchmarkSuite struct {
+	benchmark.Suite
+	_map _map.Map
+}
+
+// SetupSuite :: benchmark
+func (s *MapBenchmarkSuite) SetupSuite(c *benchmark.Context) {
+	setup.Partitions("raft").Raft()
+	setup.SetupOrDie()
+}
+
+// SetupBenchmark :: benchmark
+func (s *MapBenchmarkSuite) SetupBenchmark(c *benchmark.Context) {
+	group, err := env.Database().Partitions("raft").Connect()
+	if err != nil {
+		panic(err)
+	}
+	_map, err := group.GetMap(context.Background(), c.Name)
+	if err != nil {
+		panic(err)
+	}
+	s._map = _map
+}
+
+// TearDownBenchmark :: benchmark
+func (s *MapBenchmarkSuite) TearDownBenchmark(c *benchmark.Context) {
+	s._map.Close()
+}
+
+// BenchmarkMapPut :: benchmark
+func (s *MapBenchmarkSuite) BenchmarkMapPut(b *benchmark.Benchmark) {
+	params := []benchmark.Param{
+		benchmark.RandomString(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
+		benchmark.RandomBytes(b.GetArg("value-count").Int(1), b.GetArg("value-length").Int(128)),
+	}
+	b.Run(func(key string, value []byte) error {
+		_, err := s._map.Put(context.Background(), key, value)
+		return err
+	}, params...)
+}
+
+// BenchmarkMapGet :: benchmark
+func (s *MapBenchmarkSuite) BenchmarkMapGet(b *benchmark.Benchmark) {
+	params := []benchmark.Param{
+		benchmark.RandomString(b.GetArg("key-count").Int(1000), b.GetArg("key-length").Int(8)),
+	}
+	b.Run(func(key string) error {
+		_, err := s._map.Get(context.Background(), key)
+		return err
+	}, params...)
+}

--- a/cmd/onos-benchmarks/main.go
+++ b/cmd/onos-benchmarks/main.go
@@ -17,12 +17,13 @@ package main
 import (
 	"github.com/onosproject/onos-test/benchmark/grpc"
 	"github.com/onosproject/onos-test/benchmark/nopaxos"
+	"github.com/onosproject/onos-test/benchmark/raft"
 	"github.com/onosproject/onos-test/pkg/benchmark"
 )
 
 func main() {
 	benchmark.Register("nopaxos", &nopaxos.MapBenchmarkSuite{})
+	benchmark.Register("raft", &raft.MapBenchmarkSuite{})
 	benchmark.Register("grpc", &grpc.BenchmarkSuite{})
-
 	benchmark.Main()
 }

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/onosproject/onos-test
 go 1.12
 
 require (
-	github.com/atomix/atomix-api v0.0.0-20191021183656-837bfda65c82
-	github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e
+	github.com/atomix/atomix-api v0.0.0-20191217054529-55159c51ab6e
+	github.com/atomix/atomix-go-client v0.0.0-20191219053757-bad855985f00
 	github.com/atomix/atomix-k8s-controller v0.0.0-20191203231043-ae7d3a341174
 	github.com/dustinkirkland/golang-petname v0.0.0-20190613200456-11339a705ed2
 	github.com/fatih/color v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/atomix/atomix-api v0.0.0-20191017192115-4d6a4f8e87a3 h1:iKZxEUGEJ1ZfW
 github.com/atomix/atomix-api v0.0.0-20191017192115-4d6a4f8e87a3/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
 github.com/atomix/atomix-api v0.0.0-20191021183656-837bfda65c82 h1:jqTiJj5KfEADMgkVd06NhUC0DxSLwrWE56KghT9vGgw=
 github.com/atomix/atomix-api v0.0.0-20191021183656-837bfda65c82/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
+github.com/atomix/atomix-api v0.0.0-20191217054529-55159c51ab6e h1:j4GEpQhi/Z2vpwA0icEQZAOemoUU7vjSIVWjRzFyWps=
+github.com/atomix/atomix-api v0.0.0-20191217054529-55159c51ab6e/go.mod h1:joWKUd0zIeYbAQ0vmYHGsnV03ZgRalhceHgnJ3EN0mI=
 github.com/atomix/atomix-go-client v0.0.0-20190807011524-58b4352273d7 h1:XE+KsvclmfZjbqYDhBqeK8wHDDHYB/FiwGeLcBurYoM=
 github.com/atomix/atomix-go-client v0.0.0-20190807011524-58b4352273d7/go.mod h1:P/m0xcEzXviZLULk78gYlJr0mHjXCZAcem3kOkvwzhA=
 github.com/atomix/atomix-go-client v0.0.0-20190814013624-2b7049842ee1 h1:SW6b1TIATnNmsKrnGaoweY+uLezgUEKT61z3IGLKOts=
@@ -51,6 +53,8 @@ github.com/atomix/atomix-go-client v0.0.0-20191022230401-78955a5abbef h1:RePrb4E
 github.com/atomix/atomix-go-client v0.0.0-20191022230401-78955a5abbef/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
 github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e h1:aLn+oZd73fkB11hrCGuqpFPug7rleIT0cCxloffYzMM=
 github.com/atomix/atomix-go-client v0.0.0-20191127222459-36981d701c6e/go.mod h1:3VrFe1rCx3N6puiQOS0L9XoReGSaapaSH9pVZ3vW614=
+github.com/atomix/atomix-go-client v0.0.0-20191219053757-bad855985f00 h1:ZlWT6LwOC6KD/XqaDnJMJcx7sNotRsONjwseYhcNzXY=
+github.com/atomix/atomix-go-client v0.0.0-20191219053757-bad855985f00/go.mod h1:riSQMsP+Pn2ZffC1AiPAc9HhTwcnlPRYTmW73KNM7hA=
 github.com/atomix/atomix-go-local v0.0.0-20190827233944-938e35b06834/go.mod h1:qLBTOiVKoEqzYOjgxIgWFa+Hfa3SR+VexA6jGBcv0HA=
 github.com/atomix/atomix-go-local v0.0.0-20190828183508-3db728c0fc3b/go.mod h1:VnwyXJvHzUHuVzzTmPhZ6/ktbBnz3CZk3aKMX7VlTmY=
 github.com/atomix/atomix-go-local v0.0.0-20190830183800-73f964b0f75a h1:O/17kCIR6b+QeSkNpP12g/xTiDg976KSIS/8SSJ6Z/8=
@@ -69,6 +73,7 @@ github.com/atomix/atomix-go-local v0.0.0-20191018192811-4de2cabe75ef/go.mod h1:L
 github.com/atomix/atomix-go-local v0.0.0-20191021234710-cca1c26bf4d8/go.mod h1:oRfnzGG5NU/uAQclc6chtLQ97/7WC5u+4t8lDouZIIE=
 github.com/atomix/atomix-go-local v0.0.0-20191108201451-9131cc896ed6 h1:qMdzRqZt7Jj7iyQOGRzQjoPRSTCRXjwKkPAhRUsYewo=
 github.com/atomix/atomix-go-local v0.0.0-20191108201451-9131cc896ed6/go.mod h1:aI/yXHQlpmA3DlJwFtmfvBSA6hyk1ANZLeXRYdZZ9wk=
+github.com/atomix/atomix-go-local v0.0.0-20191218214123-a72c188f976e/go.mod h1:TNYeoT2heNTgytoOXq1juZ/X/6GctzWC1bTmmAUBWIM=
 github.com/atomix/atomix-go-node v0.0.0-20190827191929-2d3dc9c550d9/go.mod h1:PL1T5R78itch1QC1CN4JmbRL/2XQlg4R95R14822C6Q=
 github.com/atomix/atomix-go-node v0.0.0-20190828183436-fc30340cd8db/go.mod h1:dyh8Bb50qKfMlpqDE6X+dQ1tZ399WKEABa3ntDYImnA=
 github.com/atomix/atomix-go-node v0.0.0-20190830183721-649263a17223/go.mod h1:KJxB/MAgndAbyCOqTV2hatw7lExiZZs7QCOr45IfC9U=
@@ -89,6 +94,8 @@ github.com/atomix/atomix-go-node v0.0.0-20191018192345-6fbb86e5f5ef/go.mod h1:Sm
 github.com/atomix/atomix-go-node v0.0.0-20191021234659-c841a97bec89/go.mod h1:wLJ9+8FK7p8R8tz3bXPQ6GTvpwhkwjyPomkL9ok5AzM=
 github.com/atomix/atomix-go-node v0.0.0-20191108201428-59c0962b63c8 h1:M9Spu1hySxpvTSZlwBkhcgPCxzS8GL+4Oizn2hxAbd4=
 github.com/atomix/atomix-go-node v0.0.0-20191108201428-59c0962b63c8/go.mod h1:wLJ9+8FK7p8R8tz3bXPQ6GTvpwhkwjyPomkL9ok5AzM=
+github.com/atomix/atomix-go-node v0.0.0-20191218180435-f58b519050d0/go.mod h1:CwNyxY+AwoQt76lt5EjK7PCIVuNe48c5mh/kJNBBEAg=
+github.com/atomix/atomix-go-node v0.0.0-20191218215657-d6b301251224/go.mod h1:Io61YHRSVo0k3wgq+ZSZH0Wyjrp7B4pNC5Jj0gQ+Ko8=
 github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68 h1:PCOXQ9q2rP/oYVNAFHR1LIqyD5JXQ19saZUKc4MkfR8=
 github.com/atomix/atomix-k8s-controller v0.0.0-20190620084759-d5e65f7fbf68/go.mod h1:vdmRfGKhgD28STeLKeKoq3tMZOyTR0l3WSG9QCrZWs0=
 github.com/atomix/atomix-k8s-controller v0.0.0-20190905035228-0c2f92a4bc0e h1:YJyjc60GiCyyWttQtVmLutmUJH41Wyqe/i5h7UdLwkc=

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -16,15 +16,12 @@ package benchmark
 
 import (
 	"math"
-	"math/rand"
 	"reflect"
 	"sort"
 	"strconv"
 	"sync"
 	"time"
 )
-
-const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNNOPQRSTUVWXYZ1234567890"
 
 const warmUpDuration = 30 * time.Second
 const aggBatchSize = 100
@@ -194,7 +191,7 @@ func (b *Benchmark) prepare(next interface{}, params []Param) func(...interface{
 
 	// Prepare the benchmark parameters
 	for _, param := range params {
-		param.reset()
+		param.Reset()
 	}
 	return f
 }
@@ -219,7 +216,7 @@ func (b *Benchmark) warm(f func(...interface{}), params []Param) {
 	for time.Since(start) < warmUpDuration {
 		args := make([]interface{}, len(params))
 		for j, arg := range params {
-			args[j] = arg.next()
+			args[j] = arg.Next()
 		}
 		requestCh <- args
 	}
@@ -295,7 +292,7 @@ func (b *Benchmark) run(f func(...interface{}), params []Param) (int, time.Durat
 	for (b.requests == 0 || requests < b.requests) && (b.duration == nil || time.Since(start) < *b.duration) {
 		args := make([]interface{}, len(params))
 		for j, arg := range params {
-			args[j] = arg.next()
+			args[j] = arg.Next()
 		}
 		requestCh <- args
 		requests++
@@ -324,117 +321,11 @@ func (b *Benchmark) run(f func(...interface{}), params []Param) (int, time.Durat
 
 // Param is an interface for benchmark parameters
 type Param interface {
-	// reset resets the benchmark parameter
-	reset()
+	// Reset resets the benchmark parameter
+	Reset()
 
-	// next returns the next instance of the benchmark parameter
-	next() interface{}
-}
-
-// RandomStringFromSet returns a random string parameter
-func RandomStringFromSet(count int, length int) Param {
-	return &RandomStringFromSetParam{
-		count:  count,
-		length: length,
-	}
-}
-
-// RandomStringFromSetParam is a random string parameter
-type RandomStringFromSetParam struct {
-	count  int
-	length int
-	args   []string
-}
-
-func (a *RandomStringFromSetParam) reset() {
-	a.args = make([]string, a.count)
-	for i := 0; i < a.count; i++ {
-		bytes := make([]byte, a.length)
-		for j := 0; j < a.length; j++ {
-			bytes[j] = chars[rand.Intn(len(chars))]
-		}
-		a.args[i] = string(bytes)
-	}
-}
-
-func (a *RandomStringFromSetParam) next() interface{} {
-	return a.args[rand.Intn(len(a.args))]
-}
-
-// RandomString returns a random string parameter
-func RandomString(length int) Param {
-	return &RandomStringParam{
-		length: length,
-	}
-}
-
-// RandomStringParam is a random string parameter
-type RandomStringParam struct {
-	length int
-	args   []string
-}
-
-func (a *RandomStringParam) reset() {}
-
-func (a *RandomStringParam) next() interface{} {
-	bytes := make([]byte, a.length)
-	for j := 0; j < a.length; j++ {
-		bytes[j] = chars[rand.Intn(len(chars))]
-	}
-	return string(bytes)
-}
-
-// RandomBytesFromSet returns a random bytes parameter
-func RandomBytesFromSet(count int, length int) Param {
-	return &RandomBytesFromSetParam{
-		count:  count,
-		length: length,
-	}
-}
-
-// RandomBytesFromSetParam is a random string parameter
-type RandomBytesFromSetParam struct {
-	count  int
-	length int
-	args   [][]byte
-}
-
-func (a *RandomBytesFromSetParam) reset() {
-	a.args = make([][]byte, a.count)
-	for i := 0; i < a.count; i++ {
-		bytes := make([]byte, a.length)
-		for j := 0; j < a.length; j++ {
-			bytes[j] = chars[rand.Intn(len(chars))]
-		}
-		a.args[i] = bytes
-	}
-}
-
-func (a *RandomBytesFromSetParam) next() interface{} {
-	return a.args[rand.Intn(len(a.args))]
-}
-
-// RandomBytes returns a random bytes parameter
-func RandomBytes(length int) Param {
-	return &RandomBytesParam{
-		length: length,
-	}
-}
-
-// RandomBytesParam is a random string parameter
-type RandomBytesParam struct {
-	length int
-	args   [][]byte
-}
-
-func (a *RandomBytesParam) reset() {}
-
-func (a *RandomBytesParam) next() interface{} {
-	bytes := make([]byte, a.length)
-	for j := 0; j < a.length; j++ {
-		bytes[j] = chars[rand.Intn(len(chars))]
-	}
-	return bytes
+	// Next returns the Next instance of the benchmark parameter
+	Next() interface{}
 }
 
 // getBenchmarks returns a list of benchmarks in the given suite

--- a/pkg/benchmark/benchmark.go
+++ b/pkg/benchmark/benchmark.go
@@ -331,22 +331,22 @@ type Param interface {
 	next() interface{}
 }
 
-// RandomString returns a random string parameter
-func RandomString(count int, length int) Param {
-	return &RandomStringParam{
+// RandomStringFromSet returns a random string parameter
+func RandomStringFromSet(count int, length int) Param {
+	return &RandomStringFromSetParam{
 		count:  count,
 		length: length,
 	}
 }
 
-// RandomStringParam is a random string parameter
-type RandomStringParam struct {
+// RandomStringFromSetParam is a random string parameter
+type RandomStringFromSetParam struct {
 	count  int
 	length int
 	args   []string
 }
 
-func (a *RandomStringParam) reset() {
+func (a *RandomStringFromSetParam) reset() {
 	a.args = make([]string, a.count)
 	for i := 0; i < a.count; i++ {
 		bytes := make([]byte, a.length)
@@ -357,26 +357,49 @@ func (a *RandomStringParam) reset() {
 	}
 }
 
-func (a *RandomStringParam) next() interface{} {
+func (a *RandomStringFromSetParam) next() interface{} {
 	return a.args[rand.Intn(len(a.args))]
 }
 
-// RandomBytes returns a random bytes parameter
-func RandomBytes(count int, length int) Param {
-	return &RandomBytesParam{
+// RandomString returns a random string parameter
+func RandomString(length int) Param {
+	return &RandomStringParam{
+		length: length,
+	}
+}
+
+// RandomStringParam is a random string parameter
+type RandomStringParam struct {
+	length int
+	args   []string
+}
+
+func (a *RandomStringParam) reset() {}
+
+func (a *RandomStringParam) next() interface{} {
+	bytes := make([]byte, a.length)
+	for j := 0; j < a.length; j++ {
+		bytes[j] = chars[rand.Intn(len(chars))]
+	}
+	return string(bytes)
+}
+
+// RandomBytesFromSet returns a random bytes parameter
+func RandomBytesFromSet(count int, length int) Param {
+	return &RandomBytesFromSetParam{
 		count:  count,
 		length: length,
 	}
 }
 
-// RandomBytesParam is a random string parameter
-type RandomBytesParam struct {
+// RandomBytesFromSetParam is a random string parameter
+type RandomBytesFromSetParam struct {
 	count  int
 	length int
 	args   [][]byte
 }
 
-func (a *RandomBytesParam) reset() {
+func (a *RandomBytesFromSetParam) reset() {
 	a.args = make([][]byte, a.count)
 	for i := 0; i < a.count; i++ {
 		bytes := make([]byte, a.length)
@@ -387,8 +410,31 @@ func (a *RandomBytesParam) reset() {
 	}
 }
 
-func (a *RandomBytesParam) next() interface{} {
+func (a *RandomBytesFromSetParam) next() interface{} {
 	return a.args[rand.Intn(len(a.args))]
+}
+
+// RandomBytes returns a random bytes parameter
+func RandomBytes(length int) Param {
+	return &RandomBytesParam{
+		length: length,
+	}
+}
+
+// RandomBytesParam is a random string parameter
+type RandomBytesParam struct {
+	length int
+	args   [][]byte
+}
+
+func (a *RandomBytesParam) reset() {}
+
+func (a *RandomBytesParam) next() interface{} {
+	bytes := make([]byte, a.length)
+	for j := 0; j < a.length; j++ {
+		bytes[j] = chars[rand.Intn(len(chars))]
+	}
+	return bytes
 }
 
 // getBenchmarks returns a list of benchmarks in the given suite

--- a/pkg/benchmark/params/params.go
+++ b/pkg/benchmark/params/params.go
@@ -84,7 +84,6 @@ func RandomString(length int) benchmark.Param {
 // RandomStringParam is a random string parameter
 type RandomStringParam struct {
 	length int
-	args   []string
 }
 
 // Reset resets the parameter
@@ -109,7 +108,6 @@ func RandomBytes(length int) benchmark.Param {
 // RandomBytesParam is a random string parameter
 type RandomBytesParam struct {
 	length int
-	args   [][]byte
 }
 
 // Reset resets the parameter

--- a/pkg/benchmark/params/params.go
+++ b/pkg/benchmark/params/params.go
@@ -1,0 +1,125 @@
+// Copyright 2020-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package params
+
+import (
+	"github.com/onosproject/onos-test/pkg/benchmark"
+	"math/rand"
+)
+
+const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNNOPQRSTUVWXYZ1234567890"
+
+// RandomChoice returns a parameter that chooses a random value from a set
+func RandomChoice(set benchmark.Param) benchmark.Param {
+	return &RandomChoiceParam{
+		set: set,
+	}
+}
+
+// RandomChoiceParam is a parameter that chooses a random value from a set
+type RandomChoiceParam struct {
+	set    benchmark.Param
+	values []interface{}
+}
+
+// Reset resets the parameter
+func (p *RandomChoiceParam) Reset() {
+	p.set.Reset()
+	p.values = p.set.Next().([]interface{})
+}
+
+// Next returns the next random value from the set
+func (p *RandomChoiceParam) Next() interface{} {
+	return p.values[rand.Intn(len(p.values))]
+}
+
+// SetOf returns a parameter that constructs a set of values of the given parameter type
+func SetOf(valueType benchmark.Param, size int) benchmark.Param {
+	return &SetParam{
+		valueType: valueType,
+		size:      size,
+	}
+}
+
+// SetParam is a parameter that returns a random set of values
+type SetParam struct {
+	valueType benchmark.Param
+	size      int
+	set       []interface{}
+}
+
+// Reset resets the parameter
+func (p *SetParam) Reset() {
+	p.valueType.Reset()
+	p.set = make([]interface{}, p.size)
+	for i := 0; i < p.size; i++ {
+		p.set[i] = p.valueType.Next()
+	}
+}
+
+// Next returns the random set
+func (p *SetParam) Next() interface{} {
+	return p.set
+}
+
+// RandomString returns a random string parameter
+func RandomString(length int) benchmark.Param {
+	return &RandomStringParam{
+		length: length,
+	}
+}
+
+// RandomStringParam is a random string parameter
+type RandomStringParam struct {
+	length int
+	args   []string
+}
+
+// Reset resets the parameter
+func (a *RandomStringParam) Reset() {}
+
+// Next returns a random string
+func (a *RandomStringParam) Next() interface{} {
+	bytes := make([]byte, a.length)
+	for j := 0; j < a.length; j++ {
+		bytes[j] = chars[rand.Intn(len(chars))]
+	}
+	return string(bytes)
+}
+
+// RandomBytes returns a random bytes parameter
+func RandomBytes(length int) benchmark.Param {
+	return &RandomBytesParam{
+		length: length,
+	}
+}
+
+// RandomBytesParam is a random string parameter
+type RandomBytesParam struct {
+	length int
+	args   [][]byte
+}
+
+// Reset resets the parameter
+func (a *RandomBytesParam) Reset() {}
+
+// Next returns a random byte slice
+func (a *RandomBytesParam) Next() interface{} {
+	bytes := make([]byte, a.length)
+	for j := 0; j < a.length; j++ {
+		bytes[j] = chars[rand.Intn(len(chars))]
+	}
+	return bytes
+}

--- a/pkg/benchmark/worker.go
+++ b/pkg/benchmark/worker.go
@@ -153,8 +153,14 @@ func (w *Worker) SetupBenchmark(ctx context.Context, request *BenchmarkRequest) 
 		return nil, err
 	}
 
+	context := newContext(request.Benchmark, request.Args)
 	if setupBenchmark, ok := suite.(SetupBenchmark); ok {
-		setupBenchmark.SetupBenchmark(newContext(request.Benchmark, request.Args))
+		setupBenchmark.SetupBenchmark(context)
+	}
+
+	methods := reflect.TypeOf(suite)
+	if method, ok := methods.MethodByName("Setup" + request.Benchmark); ok {
+		method.Func.Call([]reflect.Value{reflect.ValueOf(suite), reflect.ValueOf(context)})
 	}
 
 	step.Complete()
@@ -172,8 +178,14 @@ func (w *Worker) TearDownBenchmark(ctx context.Context, request *BenchmarkReques
 		return nil, err
 	}
 
+	context := newContext(request.Benchmark, request.Args)
 	if tearDownBenchmark, ok := suite.(TearDownBenchmark); ok {
-		tearDownBenchmark.TearDownBenchmark(newContext(request.Benchmark, request.Args))
+		tearDownBenchmark.TearDownBenchmark(context)
+	}
+
+	methods := reflect.TypeOf(suite)
+	if method, ok := methods.MethodByName("TearDown" + request.Benchmark); ok {
+		method.Func.Call([]reflect.Value{reflect.ValueOf(suite), reflect.ValueOf(context)})
 	}
 
 	step.Complete()


### PR DESCRIPTION
This PR adds Raft benchmarks to the benchmark images. It also cleans up the benchmark params API and moves parameters to a separate package. The addition of Raft benchmarks here is only temporary.