### PR TITLE
Add a --iterations flag to onit to allow a test to be run multiple times

### DIFF
--- a/pkg/onit/cli/test.go
+++ b/pkg/onit/cli/test.go
@@ -37,6 +37,7 @@ func getTestCommand() *cobra.Command {
 	cmd.Flags().StringP("suite", "s", "", "the test suite to run")
 	cmd.Flags().StringP("test", "t", "", "the name of the test method to run")
 	cmd.Flags().Duration("timeout", 10*time.Minute, "test timeout")
+	cmd.Flags().String("iterations", "1", "number of iterations")
 	cmd.Flags().Bool("no-teardown", false, "do not tear down clusters following tests")
 
 	_ = cmd.MarkFlagRequired("image")
@@ -52,6 +53,7 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 	testName, _ := cmd.Flags().GetString("test")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	pullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
+	iterations, _ := cmd.Flags().GetString("iterations")
 
 	config := &test.Config{
 		ID:              random.NewPetName(2),
@@ -61,6 +63,7 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 		Test:            testName,
 		Env:             onitcluster.GetArgsAsEnv(sets),
 		Timeout:         timeout,
+		Iterations:      iterations,
 	}
 
 	job := &cluster.Job{

--- a/pkg/onit/cli/test.go
+++ b/pkg/onit/cli/test.go
@@ -38,6 +38,7 @@ func getTestCommand() *cobra.Command {
 	cmd.Flags().StringP("test", "t", "", "the name of the test method to run")
 	cmd.Flags().Duration("timeout", 10*time.Minute, "test timeout")
 	cmd.Flags().Int("iterations", 1, "number of iterations")
+	cmd.Flags().Bool("until-failure", false, "run until an error is detected")
 	cmd.Flags().Bool("no-teardown", false, "do not tear down clusters following tests")
 
 	_ = cmd.MarkFlagRequired("image")
@@ -54,6 +55,11 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	pullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
 	iterations, _ := cmd.Flags().GetInt("iterations")
+	untilFailure, _ := cmd.Flags().GetBool("until-failure")
+
+	if untilFailure {
+		iterations = -1
+	}
 
 	config := &test.Config{
 		ID:              random.NewPetName(2),

--- a/pkg/onit/cli/test.go
+++ b/pkg/onit/cli/test.go
@@ -37,7 +37,7 @@ func getTestCommand() *cobra.Command {
 	cmd.Flags().StringP("suite", "s", "", "the test suite to run")
 	cmd.Flags().StringP("test", "t", "", "the name of the test method to run")
 	cmd.Flags().Duration("timeout", 10*time.Minute, "test timeout")
-	cmd.Flags().String("iterations", "1", "number of iterations")
+	cmd.Flags().Int("iterations", 1, "number of iterations")
 	cmd.Flags().Bool("no-teardown", false, "do not tear down clusters following tests")
 
 	_ = cmd.MarkFlagRequired("image")
@@ -53,7 +53,7 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 	testName, _ := cmd.Flags().GetString("test")
 	timeout, _ := cmd.Flags().GetDuration("timeout")
 	pullPolicy, _ := cmd.Flags().GetString("image-pull-policy")
-	iterations, _ := cmd.Flags().GetString("iterations")
+	iterations, _ := cmd.Flags().GetInt("iterations")
 
 	config := &test.Config{
 		ID:              random.NewPetName(2),

--- a/pkg/test/config.go
+++ b/pkg/test/config.go
@@ -31,6 +31,7 @@ const (
 	testImagePullPolicyEnv = "TEST_IMAGE_PULL_POLICY"
 	testSuiteEnv           = "TEST_SUITE"
 	testNameEnv            = "TEST_NAME"
+	testIterationsEnv      = "TEST_ITERATIONS"
 )
 
 const (
@@ -46,12 +47,14 @@ func GetConfigFromEnv() *Config {
 		value := keyval[strings.Index(keyval, "=")+1:]
 		env[key] = value
 	}
+
 	return &Config{
 		ID:              os.Getenv(testJobEnv),
 		Image:           os.Getenv(testImageEnv),
 		ImagePullPolicy: corev1.PullPolicy(os.Getenv(testImagePullPolicyEnv)),
 		Suite:           os.Getenv(testSuiteEnv),
 		Test:            os.Getenv(testNameEnv),
+		Iterations:      os.Getenv(testIterationsEnv),
 		Env:             env,
 	}
 }
@@ -65,6 +68,7 @@ type Config struct {
 	Test            string
 	Env             map[string]string
 	Timeout         time.Duration
+	Iterations      string
 }
 
 // ToEnv returns the configuration as a mapping of environment variables
@@ -75,6 +79,7 @@ func (c *Config) ToEnv() map[string]string {
 	env[testImagePullPolicyEnv] = string(c.ImagePullPolicy)
 	env[testSuiteEnv] = c.Suite
 	env[testNameEnv] = c.Test
+	env[testIterationsEnv] = c.Iterations
 	return env
 }
 

--- a/pkg/test/config.go
+++ b/pkg/test/config.go
@@ -17,6 +17,7 @@ package test
 import (
 	corev1 "k8s.io/api/core/v1"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -48,13 +49,14 @@ func GetConfigFromEnv() *Config {
 		env[key] = value
 	}
 
+	iterations, _ := strconv.Atoi(os.Getenv(testIterationsEnv))
 	return &Config{
 		ID:              os.Getenv(testJobEnv),
 		Image:           os.Getenv(testImageEnv),
 		ImagePullPolicy: corev1.PullPolicy(os.Getenv(testImagePullPolicyEnv)),
 		Suite:           os.Getenv(testSuiteEnv),
 		Test:            os.Getenv(testNameEnv),
-		Iterations:      os.Getenv(testIterationsEnv),
+		Iterations:      iterations,
 		Env:             env,
 	}
 }
@@ -68,7 +70,7 @@ type Config struct {
 	Test            string
 	Env             map[string]string
 	Timeout         time.Duration
-	Iterations      string
+	Iterations      int
 }
 
 // ToEnv returns the configuration as a mapping of environment variables
@@ -79,7 +81,7 @@ func (c *Config) ToEnv() map[string]string {
 	env[testImagePullPolicyEnv] = string(c.ImagePullPolicy)
 	env[testSuiteEnv] = c.Suite
 	env[testNameEnv] = c.Test
-	env[testIterationsEnv] = c.Iterations
+	env[testIterationsEnv] = strconv.Itoa(c.Iterations)
 	return env
 }
 

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -62,8 +62,7 @@ func (c *Coordinator) Run() error {
 		suites = strings.Split(c.config.Suite, ",")
 	}
 
-	iterations, _ := strconv.Atoi(c.config.Iterations)
-	for iteration := 1; iteration <= iterations || c.config.Iterations == "-1"; iteration++ {
+	for iteration := 1; iteration <= c.config.Iterations || c.config.Iterations < 0; iteration++ {
 		workers := make([]*WorkerTask, len(suites))
 		for i, suite := range suites {
 			jobID := newJobID(c.config.ID+"-"+strconv.Itoa(iteration), suite)

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -61,29 +62,37 @@ func (c *Coordinator) Run() error {
 		suites = strings.Split(c.config.Suite, ",")
 	}
 
-	workers := make([]*WorkerTask, len(suites))
-	for i, suite := range suites {
-		jobID := newJobID(c.config.ID, suite)
-		config := &Config{
-			ID:              jobID,
-			Image:           c.config.Image,
-			ImagePullPolicy: c.config.ImagePullPolicy,
-			Suite:           suite,
-			Test:            c.config.Test,
-			Env:             c.config.Env,
+	iterations, _ := strconv.Atoi(c.config.Iterations)
+	for iteration := 1; iteration <= iterations || c.config.Iterations == "-1"; iteration++ {
+		workers := make([]*WorkerTask, len(suites))
+		for i, suite := range suites {
+			jobID := newJobID(c.config.ID+"-"+strconv.Itoa(iteration), suite)
+			config := &Config{
+				ID:              jobID,
+				Image:           c.config.Image,
+				ImagePullPolicy: c.config.ImagePullPolicy,
+				Suite:           suite,
+				Test:            c.config.Test,
+				Env:             c.config.Env,
+				Iterations:      c.config.Iterations,
+			}
+			testCluster, err := cluster.NewCluster(config.ID)
+			if err != nil {
+				return err
+			}
+			worker := &WorkerTask{
+				client:  c.client,
+				cluster: testCluster,
+				config:  config,
+			}
+			workers[i] = worker
 		}
-		testCluster, err := cluster.NewCluster(config.ID)
+		err := runWorkers(workers)
 		if err != nil {
 			return err
 		}
-		worker := &WorkerTask{
-			client:  c.client,
-			cluster: testCluster,
-			config:  config,
-		}
-		workers[i] = worker
 	}
-	return runWorkers(workers)
+	return nil
 }
 
 // runWorkers runs the given test workers


### PR DESCRIPTION
This PR adds a --iterations flag to onit, which allows a test to be repeated the given number of times. If an iteration count of -1 is given, the test will rerun until it encounters an error.

This implements #213 