### PR TITLE
Assign cpu and memory resources to core subsystems

### DIFF
--- a/pkg/onit/cluster/service.go
+++ b/pkg/onit/cluster/service.go
@@ -65,24 +65,24 @@ type Service struct {
 
 // CPURequest returns the cpu request for a deployment container
 func (s *Service) CPURequest() string {
-	return GetArg(s.name, "cpu.request").String(s.cpuRequest)
+	return GetArg(s.name, "cpu", "request").String(s.cpuRequest)
 
 }
 
 // MemoryRequest returns the memory request for a deployment container
 func (s *Service) MemoryRequest() string {
-	return GetArg(s.name, "memory.request").String(s.memoryRequest)
+	return GetArg(s.name, "memory", "request").String(s.memoryRequest)
 
 }
 
 // CPULimit returns cpu limit for a deployment container
 func (s *Service) CPULimit() string {
-	return GetArg(s.name, "cpu.limit").String(s.cpuLimit)
+	return GetArg(s.name, "cpu", "limit").String(s.cpuLimit)
 }
 
 // MemoryLimit returns the memory limit for a deployment container
 func (s *Service) MemoryLimit() string {
-	return GetArg(s.name, "memory.limit").String(s.memoryLimit)
+	return GetArg(s.name, "memory", "limit").String(s.memoryLimit)
 }
 
 // SetMemoryLimit sets memory limit for a deployment container

--- a/pkg/onit/cluster/service.go
+++ b/pkg/onit/cluster/service.go
@@ -59,6 +59,8 @@ type Service struct {
 	args          []string
 	cpuRequest    string
 	memoryRequest string
+	cpuLimit      string
+	memoryLimit   string
 }
 
 // CPURequest returns the cpu request for a deployment container
@@ -73,14 +75,24 @@ func (s *Service) MemoryRequest() string {
 
 }
 
-// MemoryLimit returns the memory limit for a deployment container
-func (s *Service) MemoryLimit() string {
-	return GetArg(s.name, "memory.limit").String(s.memoryRequest)
-}
-
 // CPULimit returns cpu limit for a deployment container
 func (s *Service) CPULimit() string {
-	return GetArg(s.name, "cpu.limit").String(s.memoryRequest)
+	return GetArg(s.name, "cpu.limit").String(s.cpuLimit)
+}
+
+// MemoryLimit returns the memory limit for a deployment container
+func (s *Service) MemoryLimit() string {
+	return GetArg(s.name, "memory.limit").String(s.memoryLimit)
+}
+
+// SetMemoryLimit sets memory limit for a deployment container
+func (s *Service) SetMemoryLimit(memoryLimit string) {
+	s.memoryLimit = memoryLimit
+}
+
+// SetCPULimit sets cpu limit for a deployment container
+func (s *Service) SetCPULimit(cpuLimit string) {
+	s.cpuLimit = cpuLimit
 }
 
 // SetCPURequest sets cpu request for a deployment container

--- a/pkg/onit/setup/config.go
+++ b/pkg/onit/setup/config.go
@@ -29,6 +29,18 @@ type ConfigSetup interface {
 
 	// SetPullPolicy sets the image pull policy
 	SetPullPolicy(pullPolicy corev1.PullPolicy) ConfigSetup
+
+	// SetCpuRequest sets the cpu request
+	SetCPURequest(cpuRequest string) ConfigSetup
+
+	// SetMemoryRequest sets memory request
+	SetMemoryRequest(memoryRequest string) ConfigSetup
+
+	// SetMemoryLimit sets memory limit
+	SetMemoryLimit(memoryLimit string) ConfigSetup
+
+	// SetCPULimit sets cpu limit
+	SetCPULimit(cpuLimit string) ConfigSetup
 }
 
 var _ ConfigSetup = &clusterConfigSetup{}
@@ -50,6 +62,26 @@ func (s *clusterConfigSetup) SetImage(image string) ConfigSetup {
 
 func (s *clusterConfigSetup) SetPullPolicy(pullPolicy corev1.PullPolicy) ConfigSetup {
 	s.config.SetPullPolicy(pullPolicy)
+	return s
+}
+
+func (s *clusterConfigSetup) SetCPURequest(cpuRequest string) ConfigSetup {
+	s.config.SetCPURequest(cpuRequest)
+	return s
+}
+
+func (s *clusterConfigSetup) SetMemoryRequest(memoryRequest string) ConfigSetup {
+	s.config.SetMemoryRequest(memoryRequest)
+	return s
+}
+
+func (s *clusterConfigSetup) SetMemoryLimit(memoryLimit string) ConfigSetup {
+	s.config.SetMemoryLimit(memoryLimit)
+	return s
+}
+
+func (s *clusterConfigSetup) SetCPULimit(cpuLimit string) ConfigSetup {
+	s.config.SetCPULimit(cpuLimit)
 	return s
 }
 

--- a/pkg/onit/setup/topo.go
+++ b/pkg/onit/setup/topo.go
@@ -35,6 +35,12 @@ type TopoSetup interface {
 
 	// SetMemoryRequest sets memory request
 	SetMemoryRequest(memoryRequest string) TopoSetup
+
+	// SetMemoryLimit sets memory limit
+	SetMemoryLimit(memoryLimit string) TopoSetup
+
+	// SetCPULimit sets cpu limit
+	SetCPULimit(cpuLimit string) TopoSetup
 }
 
 var _ TopoSetup = &clusterTopoSetup{}
@@ -66,6 +72,16 @@ func (s *clusterTopoSetup) SetCPURequest(cpuRequest string) TopoSetup {
 
 func (s *clusterTopoSetup) SetMemoryRequest(memoryRequest string) TopoSetup {
 	s.topo.SetMemoryRequest(memoryRequest)
+	return s
+}
+
+func (s *clusterTopoSetup) SetMemoryLimit(memoryLimit string) TopoSetup {
+	s.topo.SetMemoryLimit(memoryLimit)
+	return s
+}
+
+func (s *clusterTopoSetup) SetCPULimit(cpuLimit string) TopoSetup {
+	s.topo.SetCPULimit(cpuLimit)
 	return s
 }
 

--- a/pkg/onit/setup/topo.go
+++ b/pkg/onit/setup/topo.go
@@ -29,6 +29,12 @@ type TopoSetup interface {
 
 	// SetPullPolicy sets the image pull policy
 	SetPullPolicy(pullPolicy corev1.PullPolicy) TopoSetup
+
+	// SetCpuRequest sets the cpu request
+	SetCPURequest(cpuRequest string) TopoSetup
+
+	// SetMemoryRequest sets memory request
+	SetMemoryRequest(memoryRequest string) TopoSetup
 }
 
 var _ TopoSetup = &clusterTopoSetup{}
@@ -50,6 +56,16 @@ func (s *clusterTopoSetup) SetImage(image string) TopoSetup {
 
 func (s *clusterTopoSetup) SetPullPolicy(pullPolicy corev1.PullPolicy) TopoSetup {
 	s.topo.SetPullPolicy(pullPolicy)
+	return s
+}
+
+func (s *clusterTopoSetup) SetCPURequest(cpuRequest string) TopoSetup {
+	s.topo.SetCPURequest(cpuRequest)
+	return s
+}
+
+func (s *clusterTopoSetup) SetMemoryRequest(memoryRequest string) TopoSetup {
+	s.topo.SetMemoryRequest(memoryRequest)
 	return s
 }
 


### PR DESCRIPTION
This PR is opened to address #214 
Users can specify  cpu and memory requests and  cpu and memory limits for core subsystems. For example:

`onit create cluster --set onos-topo.cpu.request="250m" --set onos-config.memory.limit="512Mi"`
