### PR TITLE
Fix: Enable verbose output for onit test command

### DIFF
--- a/pkg/onit/cli/test.go
+++ b/pkg/onit/cli/test.go
@@ -15,13 +15,16 @@
 package cli
 
 import (
+	"time"
+
+	"github.com/onosproject/onos-test/pkg/util/logging"
+
 	"github.com/onosproject/onos-test/pkg/cluster"
 	onitcluster "github.com/onosproject/onos-test/pkg/onit/cluster"
 	"github.com/onosproject/onos-test/pkg/test"
 	"github.com/onosproject/onos-test/pkg/util/random"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	"time"
 )
 
 func getTestCommand() *cobra.Command {
@@ -70,6 +73,7 @@ func runTestCommand(cmd *cobra.Command, _ []string) error {
 		Env:             onitcluster.GetArgsAsEnv(sets),
 		Timeout:         timeout,
 		Iterations:      iterations,
+		Verbose:         logging.GetVerbose(),
 	}
 
 	job := &cluster.Job{

--- a/pkg/test/config.go
+++ b/pkg/test/config.go
@@ -15,11 +15,12 @@
 package test
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 type testContext string
@@ -33,6 +34,7 @@ const (
 	testSuiteEnv           = "TEST_SUITE"
 	testNameEnv            = "TEST_NAME"
 	testIterationsEnv      = "TEST_ITERATIONS"
+	testVerbose            = "VERBOSE_LOGGING"
 )
 
 const (
@@ -50,6 +52,7 @@ func GetConfigFromEnv() *Config {
 	}
 
 	iterations, _ := strconv.Atoi(os.Getenv(testIterationsEnv))
+	verbose, _ := strconv.ParseBool(os.Getenv(testVerbose))
 	return &Config{
 		ID:              os.Getenv(testJobEnv),
 		Image:           os.Getenv(testImageEnv),
@@ -57,6 +60,7 @@ func GetConfigFromEnv() *Config {
 		Suite:           os.Getenv(testSuiteEnv),
 		Test:            os.Getenv(testNameEnv),
 		Iterations:      iterations,
+		Verbose:         verbose,
 		Env:             env,
 	}
 }
@@ -71,6 +75,7 @@ type Config struct {
 	Env             map[string]string
 	Timeout         time.Duration
 	Iterations      int
+	Verbose         bool
 }
 
 // ToEnv returns the configuration as a mapping of environment variables
@@ -82,6 +87,10 @@ func (c *Config) ToEnv() map[string]string {
 	env[testSuiteEnv] = c.Suite
 	env[testNameEnv] = c.Test
 	env[testIterationsEnv] = strconv.Itoa(c.Iterations)
+	if c.Verbose {
+		env[testVerbose] = strconv.FormatBool(c.Verbose)
+	}
+
 	return env
 }
 


### PR DESCRIPTION
This PR fixes the verbose flag for onit test command. Issue #224 