### PR TITLE
Make atomix service and deployment  more generic

### DIFF
--- a/pkg/onit/cli/create.go
+++ b/pkg/onit/cli/create.go
@@ -84,7 +84,7 @@ func runCreateClusterCommand(cmd *cobra.Command, _ []string) error {
 	args, _ := cmd.Flags().GetStringToString("set")
 	onitcluster.SetArgs(args)
 	setup := setup.New(api)
-	setup.Atomix()
+	setup.Atomix().SetReplicas(1)
 	setup.Database().Raft()
 	setup.Topo().SetReplicas(1)
 	setup.Config().SetReplicas(1)

--- a/pkg/onit/setup/atomix.go
+++ b/pkg/onit/setup/atomix.go
@@ -26,6 +26,9 @@ type AtomixSetup interface {
 
 	// SetPullPolicy sets the image pull policy
 	SetPullPolicy(pullPolicy corev1.PullPolicy) AtomixSetup
+
+	// SetReplicas sets the number of replicas to deploy
+	SetReplicas(replicas int) AtomixSetup
 }
 
 var _ AtomixSetup = &clusterAtomixSetup{}
@@ -42,6 +45,11 @@ func (s *clusterAtomixSetup) SetImage(image string) AtomixSetup {
 
 func (s *clusterAtomixSetup) SetPullPolicy(pullPolicy corev1.PullPolicy) AtomixSetup {
 	s.atomix.SetPullPolicy(pullPolicy)
+	return s
+}
+
+func (s *clusterAtomixSetup) SetReplicas(replicas int) AtomixSetup {
+	s.atomix.SetReplicas(replicas)
 	return s
 }
 


### PR DESCRIPTION
This PR make the atomix server and deployment more generic. It is still possible to make the deployment also generic to use cluster create deployment function but it needs more work. 

After we merge this PR we need to update tests in other repos. 