### PR TITLE
Replace and deprecate per-coordinator registry

### DIFF
--- a/pkg/benchmark/coordinator.go
+++ b/pkg/benchmark/coordinator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-test/pkg/cluster"
 	"github.com/onosproject/onos-test/pkg/kube"
+	"github.com/onosproject/onos-test/pkg/registry"
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
@@ -56,10 +57,7 @@ type Coordinator struct {
 func (c *Coordinator) Run() error {
 	var suites []string
 	if c.config.Suite == "" {
-		suites = make([]string, 0, len(Registry.benchmarks))
-		for suite := range Registry.benchmarks {
-			suites = append(suites, suite)
-		}
+		suites = registry.GetBenchmarkSuites()
 	} else {
 		suites = []string{c.config.Suite}
 	}
@@ -465,7 +463,7 @@ func (t *WorkerTask) runBenchmarks() error {
 	} else {
 		suiteStep := logging.NewStep(t.config.ID, "Run benchmark suite %s", t.config.Suite)
 		suiteStep.Start()
-		suite := Registry.benchmarks[t.config.Suite]
+		suite := registry.GetBenchmarkSuite(t.config.Suite)
 		benchmarks := getBenchmarks(suite)
 		for _, benchmark := range benchmarks {
 			benchmarkSuite := logging.NewStep(t.config.ID, "Run benchmark %s", benchmark)

--- a/pkg/benchmark/registry.go
+++ b/pkg/benchmark/registry.go
@@ -14,22 +14,10 @@
 
 package benchmark
 
+import "github.com/onosproject/onos-test/pkg/registry"
+
 // Register registers a benchmark suite
+// Deprecated: Use registry.RegisterBenchmarkSuite instead
 func Register(name string, suite BenchmarkingSuite) {
-	Registry.register(name, suite)
-}
-
-// Registry is the global benchmark registry
-var Registry = &benchmarkRegistry{
-	benchmarks: make(map[string]BenchmarkingSuite),
-}
-
-// benchmarkRegistry is a registry of runnable benchmarks
-type benchmarkRegistry struct {
-	benchmarks map[string]BenchmarkingSuite
-}
-
-// register registers a benchmark suite
-func (s *benchmarkRegistry) register(name string, suite BenchmarkingSuite) {
-	s.benchmarks[name] = suite
+	registry.RegisterBenchmarkSuite(name, suite)
 }

--- a/pkg/benchmark/worker.go
+++ b/pkg/benchmark/worker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/onosproject/onos-test/pkg/kube"
+	"github.com/onosproject/onos-test/pkg/registry"
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	"google.golang.org/grpc"
 	"net"
@@ -59,7 +60,7 @@ func (w *Worker) getSuite(name string) (BenchmarkingSuite, error) {
 	if suite, ok := w.suites[name]; ok {
 		return suite, nil
 	}
-	if suite, ok := Registry.benchmarks[name]; ok {
+	if suite := registry.GetBenchmarkSuite(name); suite != nil {
 		w.suites[name] = suite
 		return suite, nil
 	}

--- a/pkg/test/coordinator.go
+++ b/pkg/test/coordinator.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"github.com/onosproject/onos-test/pkg/cluster"
 	"github.com/onosproject/onos-test/pkg/kube"
+	"github.com/onosproject/onos-test/pkg/registry"
 	"github.com/onosproject/onos-test/pkg/util/logging"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,11 +55,7 @@ func (c *Coordinator) Run() error {
 	for iteration := 1; iteration <= c.config.Iterations || c.config.Iterations < 0; iteration++ {
 		suites := c.config.Suites
 		if len(suites) == 0 || suites[0] == "" {
-			// No suite specified - run all of them
-			suites = make([]string, 0, len(Registry.tests))
-			for suite := range Registry.tests {
-				suites = append(suites, suite)
-			}
+			suites = registry.GetTestSuites()
 		}
 		workers := make([]*WorkerTask, len(suites))
 		for i, suite := range suites {

--- a/pkg/test/registry.go
+++ b/pkg/test/registry.go
@@ -14,22 +14,10 @@
 
 package test
 
+import "github.com/onosproject/onos-test/pkg/registry"
+
 // Register registers a test suite
+// Deprecated: Use registry.RegisterTestSuite instead
 func Register(name string, suite TestingSuite) {
-	Registry.register(name, suite)
-}
-
-// Registry is the global test registry
-var Registry = &testRegistry{
-	tests: make(map[string]TestingSuite),
-}
-
-// testRegistry is a registry of runnable tests
-type testRegistry struct {
-	tests map[string]TestingSuite
-}
-
-// register registers a test suite
-func (s *testRegistry) register(name string, suite TestingSuite) {
-	s.tests[name] = suite
+	registry.RegisterTestSuite(name, suite)
 }

--- a/pkg/test/worker.go
+++ b/pkg/test/worker.go
@@ -17,6 +17,7 @@ package test
 import (
 	"fmt"
 	"github.com/onosproject/onos-test/pkg/kube"
+	"github.com/onosproject/onos-test/pkg/registry"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
@@ -42,8 +43,8 @@ type Worker struct {
 
 // Run runs a test
 func (w *Worker) Run() error {
-	test, ok := Registry.tests[w.config.Suites[0]]
-	if !ok {
+	test := registry.GetTestSuite(w.config.Suites[0])
+	if test == nil {
 		return fmt.Errorf("unknown test suite %s", w.config.Suites[0])
 	}
 


### PR DESCRIPTION
This PR deprecates the per-coordinator registry to replace it with the central registry added in #248 