### PR TITLE
Ensure schedule is called when setting up simulator

### DIFF
--- a/pkg/simulation/simulator.go
+++ b/pkg/simulation/simulator.go
@@ -181,7 +181,9 @@ func (s *Simulator) teardownSimulation() error {
 // setupSimulator sets up the simulator
 func (s *Simulator) setupSimulator() error {
 	if setupSuite, ok := s.suite.(SetupSimulator); ok {
-		return setupSuite.SetupSimulator(s)
+		if err := setupSuite.SetupSimulator(s); err != nil {
+			return err
+		}
 	}
 	if setupSuite, ok := s.suite.(ScheduleSimulator); ok {
 		setupSuite.ScheduleSimulator(s)


### PR DESCRIPTION
Simulator setup step returns too soon when simulation suite implements the `SimulatorSetup` interface.