### PR TITLE
Add kpimon checks to PCI smoke test

### DIFF
--- a/build/bin/check-kpimon-list-metrics
+++ b/build/bin/check-kpimon-list-metrics
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+""""
+ Copyright 2021-present Open Networking Foundation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Reads the standard input for CLI command output from 'onos kpimon list metrics'
+ and checks that the output is correct.
+"""
+
+import check_cli
+
+expected_headers = ['Node', 'ID', 'Cell', 'ID', 'Time', 'RRC.Conn.Avg', 'RRC.Conn.Max', 'RRC.ConnEstabAtt.Tot', 'RRC.ConnEstabSucc.Tot', 'RRC.ConnReEstabAtt.HOFail', 'RRC.ConnReEstabAtt.Other', 'RRC.ConnReEstabAtt.Tot', 'RRC.ConnReEstabAtt.reconfigFail']
+
+NODE_ID_REGEX = r'[0-9a-f]+'
+CELL_ID_REGEX = r'[0-9a-f]{15}'
+TIME_REGEX = r'([01]?[0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9].[0-9]'
+RRC_CONN_REGEX = r'^[\d]*'
+
+expected_regexes = [
+    NODE_ID_REGEX,
+    CELL_ID_REGEX,
+    TIME_REGEX,
+    RRC_CONN_REGEX,
+    RRC_CONN_REGEX,
+    RRC_CONN_REGEX,
+    RRC_CONN_REGEX,
+    RRC_CONN_REGEX,
+    RRC_CONN_REGEX,
+    RRC_CONN_REGEX,
+    RRC_CONN_REGEX
+]
+
+if __name__ == '__main__':
+    check = 'KPIMON Metrics'
+    ok,output = check_cli.check_cli_output(check, expected_headers, expected_regexes)
+    print (expected_headers)
+    if not ok:
+        print ("Check " + check + " failed")
+        exit(1)
+
+    print ("Check " + check + " passed")
+

--- a/build/bin/check-kpimon-report-interval
+++ b/build/bin/check-kpimon-report-interval
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+""""
+ Copyright 2021-present Open Networking Foundation.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ Assuming debug logs are enabled for KPIMON, retrieves latest timestamps of KPIMON debug logs,
+ calculates the time difference, and checks it matches the expected report-interval (in ms) within the retry period.
+"""
+
+import datetime
+import subprocess
+
+if __name__ == '__main__':
+    check = "KPIMON Report Period Interval"
+    expected_report_interval = 1000
+    command = 'kubectl -n micro-onos logs deploy/onos-kpimon --tail=1 | awk \'{ print $1 }\''
+
+    current_time = subprocess.check_output(args=command, shell=True).decode("utf-8").rstrip('\n')
+    current_time = datetime.datetime.strptime(current_time, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp()
+    retry = 100
+    while (retry > 0):
+        new_time = subprocess.check_output(args=command, shell=True).decode("utf-8").rstrip('\n')
+        new_time = datetime.datetime.strptime(new_time, "%Y-%m-%dT%H:%M:%S.%fZ").timestamp()
+        report_interval = int(round((new_time - current_time) * 1000, -3))
+        print ("Current report interval: " + str(report_interval) + " ms. Expected: " + str(expected_report_interval) + " ms")
+        if report_interval == expected_report_interval:
+            print ("Check " + check + " passed")
+            exit(0)
+        elif report_interval > 0 and report_interval != expected_report_interval:
+            break
+        retry -= 1
+
+    print ("Check " + check + " failed")
+    exit(1)

--- a/build/bin/smoke-onos-pci
+++ b/build/bin/smoke-onos-pci
@@ -36,6 +36,7 @@ helm install -n micro-onos $registry --set image.tag=latest \
                                      --set import.onos-cli.enabled=false \
                                      --set import.onos-pci.enabled=true \
                                      --set import.onos-kpimon.enabled=true \
+                                     --set onos-kpimon.logging.loggers.root.level=debug \
                                      sdran sdran/sd-ran
 sleep 15
 
@@ -57,6 +58,12 @@ $onos_test/build/bin/check-e2t-subscriptions 'onos-pci|onos-kpimon-v2' <$tmpfile
 $cli_command /usr/local/bin/onos pci get cells > $tmpfile
 cat $tmpfile
 $onos_test/build/bin/check-pci-get-cells <$tmpfile
+
+$cli_command /usr/local/bin/onos kpimon list metrics > $tmpfile
+cat $tmpfile
+$onos_test/build/bin/check-kpimon-list-metrics <$tmpfile
+
+$onos_test/build/bin/check-kpimon-report-interval
 
 rm $tmpfile
 


### PR DESCRIPTION
This currently works for the default 1000ms report-interval